### PR TITLE
feat: only show table of contents when flagged in metadata

### DIFF
--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -1,5 +1,6 @@
 import {
   buildBlock,
+  getMetadata,
 } from '../../scripts/lib-franklin.js';
 
 function createTemplateBlock(main, blockName, gridName) {
@@ -17,6 +18,10 @@ function createTemplateBlock(main, blockName, gridName) {
  * @param {Element} main Element to which table of contents will be added.
  */
 function createTableOfContents(main) {
+  const hasToc = getMetadata('has-toc');
+  if (!hasToc) {
+    return;
+  }
   const tocDiv = document.createElement('div');
   const allH2s = main ? main.getElementsByTagName('h2') : [];
   const tocHeader = document.createElement('h2');


### PR DESCRIPTION
Fix #70 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After: https://issue-70--petplace--hlxsites.hlx.page/

As requested by customer, a table of contents for an article should only be displayed if a metadata value is set in the article's document. The metadata name is `Has ToC`, and can be seen on the [cat drinking fountain article](https://adobe.sharepoint.com/:w:/r/sites/HelixProjects/_layouts/15/Doc.aspx?sourcedoc=%7BA63589C1-6D11-488F-8C55-B1DC6391B9E2%7D&file=cat-drinking-fountains.docx&action=default&mobileredirect=true).

Example page _with_ a toc: https://issue-70--petplace--hlxsites.hlx.page/article/cats/pet-care/cat-drinking-fountains
Example page _without_ a toc: https://issue-70--petplace--hlxsites.hlx.page/article/dogs/pet-care/dog-care/grooming-your-dog/the-ultimate-how-to-guide-for-grooming-a-dog-at-home/