### PR TITLE
feat: change arrow color on Ask Now button to white

### DIFF
--- a/templates/ask-author-page/ask-author-page.css
+++ b/templates/ask-author-page/ask-author-page.css
@@ -64,15 +64,8 @@
   font-size: 1.25rem;
 }
 
-.ask-author-page main .hero .ask-author-page-hero-auto-block a::before {
-  content: url(/icons/arrow.svg);
-  width: 24px;
-  height: 24px;
+.ask-author-page main .hero .ask-author-page-hero-auto-block .icon {
   margin-right: .5rem;
-}
-
-.ask-author-page main .hero .ask-author-page-hero-auto-block a::before svg {
-  color: white;
 }
 
 .ask-author-page main .hero .ask-author-page-hero-auto-block p {

--- a/templates/ask-author-page/ask-author-page.js
+++ b/templates/ask-author-page/ask-author-page.js
@@ -2,7 +2,7 @@ import {
   buildBlock,
   getMetadata,
   createOptimizedPicture,
-  decorateIcons
+  decorateIcons,
 } from '../../scripts/lib-franklin.js';
 
 function createTemplateBlock(main, blockName, elems = []) {

--- a/templates/ask-author-page/ask-author-page.js
+++ b/templates/ask-author-page/ask-author-page.js
@@ -2,6 +2,7 @@ import {
   buildBlock,
   getMetadata,
   createOptimizedPicture,
+  decorateIcons
 } from '../../scripts/lib-franklin.js';
 
 function createTemplateBlock(main, blockName, elems = []) {
@@ -32,12 +33,20 @@ export function loadLazy(main) {
     hero.append(h3);
   }
 
+  const arrow = document.createElement('span');
+  arrow.classList.add('icon', 'icon-arrow');
+
+  const text = document.createElement('span');
+  text.innerText = 'Ask Now';
+
   const autoBlockDiv = document.createElement('div');
   autoBlockDiv.classList.add('ask-author-page-hero-auto-block');
   const askNow = document.createElement('a');
+  askNow.append(arrow);
+  askNow.append(text);
   askNow.href = 'mailto:info@petplace.com';
-  askNow.innerText = 'Ask Now';
   autoBlockDiv.append(askNow);
+  decorateIcons(askNow);
 
   const firstName = getMetadata('author-first-name');
   const finePrint1 = document.createElement('p');


### PR DESCRIPTION
Fix #46

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After: https://issue-46-white-arrow--petplace--hlxsites.hlx.page/

It turns out that changing the color of an `svg` with the css `color` property doesn't work when the `svg` is used as the `content` of a `::before` element. I tried playing around with setting a background and using `mask`, but ultimately it seemed simpler to me to just add a new `span` element for the arrow and avoid the fancy CSS. Let me know what you think.

This change applies to:

- https://issue-46-white-arrow--petplace--hlxsites.hlx.page/tags/ask-dr-debra-common-questions