### PR TITLE
feat: build a poc for list pagination and filtering

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 helix-importer-ui
+ffetch.js

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -1,18 +1,32 @@
 import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
 
+function createCard(row) {
+  const li = document.createElement('li');
+  li.innerHTML = row.innerHTML;
+  [...li.children].forEach((div) => {
+    if (div.children.length === 1 && div.querySelector('picture')) div.className = 'cards-card-image';
+    else div.className = 'cards-card-body';
+  });
+  return li;
+}
+
 export default function decorate(block) {
   /* change to ul, li */
   const ul = document.createElement('ul');
   [...block.children].forEach((row) => {
-    const li = document.createElement('li');
-    li.innerHTML = row.innerHTML;
-    [...li.children].forEach((div) => {
-      if (div.children.length === 1 && div.querySelector('picture')) div.className = 'cards-card-image';
-      else div.className = 'cards-card-body';
-    });
-    ul.append(li);
+    ul.append(createCard(row));
   });
   ul.querySelectorAll('img').forEach((img) => img.closest('picture').replaceWith(createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }])));
   block.textContent = '';
   block.append(ul);
+
+  const observer = new MutationObserver((entries) => {
+    entries.forEach((entry) => {
+      entry.addedNodes.forEach((div) => {
+        ul.append(createCard(div));
+        div.remove();
+      });
+    });
+  });
+  observer.observe(block, { childList: true });
 }

--- a/blocks/pagination/pagination.css
+++ b/blocks/pagination/pagination.css
@@ -1,0 +1,19 @@
+.pagination ul,
+.pagination a {
+  display: flex;
+  list-style: none;
+  align-items: center;
+}
+
+.pagination ul {
+  gap: 1rem;
+}
+
+.pagination li {
+  margin: 0;
+  padding: 0;
+}
+
+.pagination a:not([aria-current])::before {
+  content: attr(aria-label);
+}

--- a/blocks/pagination/pagination.js
+++ b/blocks/pagination/pagination.js
@@ -1,0 +1,40 @@
+function renderContent(block) {
+  const usp = new URLSearchParams(window.location.search);
+  const limit = Number(usp.get('limit') || 25);
+  const page = Number(usp.get('page') || 1);
+  const cards = document.querySelector('.cards ul');
+
+  usp.set('page', page - 1);
+  const prevParams = usp.toString();
+  usp.set('page', page + 1);
+  const nextParams = usp.toString();
+
+  block.innerHTML = `
+    <nav aria-label="pagination">
+      <ul>
+        ${page > 1 ? `<li><a href="${window.location.pathname}?${prevParams}" aria-label="Previous page"><span class="icon icon-chevron"></span></a></li>` : ''}
+        <li><a href="#" aria-current="page" aria-label="Page ${page}">${page}</a></li>
+        ${cards?.childElementCount === limit ? `<li><a href="${window.location.pathname}?${nextParams}" aria-label="Next page"><span class="icon icon-chevron"></span></a></li>` : ''}
+      </ul>
+    </nav>`;
+}
+
+export default async function decorate(block) {
+  renderContent(block);
+  block.addEventListener('click', (ev) => {
+    const a = ev.target.closest('a');
+    if (!a) {
+      return;
+    }
+    ev.preventDefault();
+    if (a.getAttribute('aria-current') === 'page') {
+      return;
+    }
+    window.location.assign(a.href);
+  });
+
+  const observer = new MutationObserver(() => {
+    renderContent(block);
+  });
+  observer.observe(document.querySelector('.cards ul'), { childList: true });
+}

--- a/blocks/sub-categories/sub-categories.css
+++ b/blocks/sub-categories/sub-categories.css
@@ -4,7 +4,7 @@
 
 .sub-categories a {
   display: block;
-  padding: 0 1rem;
+  padding: 0 .5rem;
   margin-bottom: .75rem;
   border-radius: 1.1em;
   color: var(--text-color-inverted);

--- a/blocks/sub-categories/sub-categories.js
+++ b/blocks/sub-categories/sub-categories.js
@@ -26,7 +26,7 @@ export default async function decorate(block) {
     }
     link.textContent = c.Category;
     link.href = c.Path;
-    link.style.backgroundColor = c.Color;
+    link.style.backgroundColor = `var(--color-${c.Color || 'purple'})`;
     p.append(link);
     block.append(p);
   });

--- a/scripts/ffetch.js
+++ b/scripts/ffetch.js
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+async function* request(url, context) {
+  const { chunks, sheet, fetch } = context;
+  for (let offset = 0, total = Infinity; offset < total; offset += chunks) {
+    const params = new URLSearchParams(`offset=${offset}&limit=${chunks}`);
+    if (sheet) params.append(`sheet`, sheet);
+    const resp = await fetch(`${url}?${params.toString()}`);
+    if (resp.ok) {
+      const json = await resp.json();
+      total = json.total;
+      for (const entry of json.data) yield entry;
+    } else {
+      return;
+    }
+  }
+}
+
+// Operations:
+
+function withFetch(upstream, context, fetch) {
+  context.fetch = fetch;
+  return upstream;
+}
+
+function withHtmlParser(upstream, context, parseHtml) {
+  context.parseHtml = parseHtml;
+  return upstream;
+}
+
+function chunks(upstream, context, chunks) {
+  context.chunks = chunks;
+  return upstream;
+}
+
+function sheet(upstream, context, sheet) {
+  context.sheet = sheet;
+  return upstream;
+}
+
+async function* skip(upstream, context, skip) {
+  let skipped = 0;
+  for await (const entry of upstream) {
+    if (skipped < skip) {
+      skipped += 1;
+    } else {
+      yield entry;
+    }
+  }
+}
+
+async function* limit(upstream, context, limit) {
+  let yielded = 0;
+  for await (const entry of upstream) {
+    yield entry;
+    yielded += 1;
+    if (yielded === limit) {
+      return;
+    }
+  }
+}
+
+async function* map(upstream, context, fn, maxInFlight = 5) {
+  const promises = [];
+  for await (let entry of upstream) {
+    promises.push(fn(entry));
+    if (promises.length === maxInFlight) {
+      for (entry of promises) {
+        entry = await entry;
+        if (entry) yield entry;
+      }
+      promises.splice(0, promises.length);
+    }
+  }
+  for (let entry of promises) {
+    entry = await entry;
+    if (entry) yield entry;
+  }
+}
+
+async function* filter(upstream, context, fn) {
+  for await (const entry of upstream) {
+    if (fn(entry)) {
+      yield entry;
+    }
+  }
+}
+
+function slice(upstream, context, from, to) {
+  return limit(skip(upstream, context, from), context, to - from);
+}
+
+function follow(upstream, context, name, newName, maxInFlight = 5) {
+  const { fetch, parseHtml } = context;
+  return map(upstream, context, async (entry) => {
+    const value = entry[name];
+    if (value) {
+      const resp = await fetch(value);
+      return {
+        ...entry,
+        [newName || name]: resp.ok ? parseHtml(await resp.text()) : null,
+      };
+    }
+    return entry;
+  }, maxInFlight);
+}
+
+async function all(upstream) {
+  const result = [];
+  for await (const entry of upstream) {
+    result.push(entry);
+  }
+  return result;
+}
+
+async function first(upstream) {
+  /* eslint-disable-next-line no-unreachable-loop */
+  for await (const entry of upstream) {
+    return entry;
+  }
+  return null;
+}
+
+// Helper
+
+function assignOperations(generator, context) {
+  // operations that return a new generator
+  function createOperation(fn) {
+    return (...rest) => assignOperations(fn.apply(null, [generator, context, ...rest]), context);
+  }
+  const operations = {
+    skip: createOperation(skip),
+    limit: createOperation(limit),
+    slice: createOperation(slice),
+    map: createOperation(map),
+    filter: createOperation(filter),
+    follow: createOperation(follow),
+  };
+
+  // functions that either return the upstream generator or no generator at all
+  const functions = {
+    chunks: chunks.bind(null, generator, context),
+    all: all.bind(null, generator, context),
+    first: first.bind(null, generator, context),
+    withFetch: withFetch.bind(null, generator, context),
+    withHtmlParser: withHtmlParser.bind(null, generator, context),
+    sheet: sheet.bind(null, generator, context),
+  };
+
+  return Object.assign(generator, operations, functions);
+}
+
+export default function ffetch(url) {
+  let chunks = 255;
+  const fetch = (...rest) => window.fetch.apply(null, rest);
+  const parseHtml = (html) => new window.DOMParser().parseFromString(html, 'text/html');
+
+  try {
+    if ('connection' in window.navigator && window.navigator.connection.saveData === true) {
+      // request smaller chunks in save data mode
+      chunks = 64;
+    }
+  } catch (e) { /* ignore */ }
+
+  const context = { chunks, fetch, parseHtml };
+  const generator = request(url, context);
+
+  return assignOperations(generator, context);
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -32,7 +32,7 @@
   --color-blue: #678fda;
   --color-blue-dark: #5773a8;
   --color-purple: #6f69a8;
-  --color-puple-light: #978ce0;
+  --color-purple-light: #978ce0;
   --color-dark-maroon: #5d3450;
   --color-red: #ff6662;
   --color-gold: #d8c46c;


### PR DESCRIPTION
- ffetch will get articles on load and apply offset, limit and filtering a needed
- Card block will automatically add and decorate new entries when loaded async
- Pagination essentially navigates away to the next `page`
- Generic template page is updated with current category info on load

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After: https://indexes-poc--petplace--hlxsites.hlx.page/
