### PR TITLE
feat: add accessibility to slideshow

### DIFF
--- a/blocks/slideshow/aria-slideshow.js
+++ b/blocks/slideshow/aria-slideshow.js
@@ -1,0 +1,235 @@
+class ResumableInterval {
+  constructor(intervalTime, callback) {
+    this.interval = null;
+    this.intervalTime = intervalTime;
+    this.callback = callback;
+  }
+
+  start() {
+    this.interval = setInterval(() => {
+      this.callback();
+    }, this.intervalTime);
+  }
+
+  pause() {
+    clearInterval(this.interval);
+  }
+
+  resume() {
+    clearInterval(this.interval);
+    this.interval = setInterval(() => {
+      this.callback();
+    }, this.intervalTime);
+  }
+}
+
+/**
+ * @typedef Slideshow
+ * @property {HTMLElement} slideshow The container representing the slideshow
+ *  itself.
+ * @property {Array<HTMLElement>} slides Elements containing the slides that
+ *  are in the slideshow. If there is an h1 element in a slide, its value
+ *  will be used as the slide's name in aria attributes.
+ * @property {HTMLElement} [tabList] If provided, the element representing
+ *  the tabs that allow users to select individual slides in the slideshow.
+ *  This is expected to be an <ol> tag containing <li> elements representing
+ *  each tab in the tablist. Slideshows that don't support tabs can omit
+ *  this property.
+ * @property {boolean} [rotateDelay=5000] The amount of time, in milliseconds,
+ *  that the slideshow should wait when auto rotating between slides. If
+ *  falsy, the slideshow will not auto rotate.
+ */
+
+/**
+ * Sets the currently active slide to a new index in the slideshow's
+ * list of slides.
+ * @param {Slideshow} slideshowInfo Information about the slideshow being
+ *  decorated.
+ * @param {number} currentIndex Currently activated slide in the slideshow.
+ * @param {number} newIndex Index of the new slide to activate.
+ */
+export function changeSlide(slideshowInfo, currentIndex, newIndex) {
+  if (currentIndex === newIndex) {
+    // optimize if user clicks on the same tab
+    return;
+  }
+  const {
+    slideshow,
+    slides,
+    tabList,
+  } = slideshowInfo;
+
+  slides[currentIndex].setAttribute('aria-hidden', true);
+  slides[currentIndex].removeAttribute('active');
+  slides[currentIndex].setAttribute('disabled', true);
+  slides[newIndex].setAttribute('aria-hidden', false);
+  slides[newIndex].setAttribute('active', true);
+  slides[newIndex].removeAttribute('disabled');
+  if (tabList) {
+    const tabs = tabList.querySelectorAll('[role="tab"]');
+    tabs[currentIndex].setAttribute('aria-selected', false);
+    tabs[newIndex].setAttribute('aria-selected', true);
+  }
+
+  const event = new CustomEvent('hlx-slideshow-slide-changed', {
+    detail: {
+      currentIndex,
+      newIndex,
+    },
+  });
+  slideshow.dispatchEvent(event);
+}
+
+/**
+ * Retrieves a value indicating whether the user has interacted with the slideshow
+ * in any way (such as clicking one of its tabs, or using the keyboard).
+ * @param {HTMLElement} slideshow Container element for the slideshow as a whole.
+ * @returns {boolean} True if the user has manually interacted with the slideshow,
+ *  false otherwise.
+ */
+function isSlideshowInteracted(slideshow) {
+  return !!slideshow.dataset.interacted;
+}
+
+/**
+ * Sets the value that specifies whether the user has manually interacted with
+ * the slideshow in some way.
+ * @param {HTMLElement} slideshow Container element for the slideshow as a whole.
+ * @param {boolean} isInteracted Indicates whether the user has interacted with the
+ *  slideshow or not.
+ */
+function setSlideshowInteracted(slideshow, isInteracted) {
+  slideshow.dataset.interacted = isInteracted;
+}
+
+/**
+ * Decorates the element containing the slideshow itself with required
+ * accessibility attributes.
+ * @param {HTMLElement} slideshow Element to decorate.
+ */
+function decorateSlideshow(slideshow) {
+  slideshow.setAttribute('role', 'group');
+  slideshow.setAttribute('aria-roledescription', 'carousel');
+}
+
+/**
+ * Decorates slide elements within a slideshow with the required attributes
+ * and functionality for making the slideshow fully accessible.
+ * @param {Array<HTMLElement>} slides Individual slide elements that make up the
+ *  slideshow.
+ * @returns {Array<string>} The names of each slide.
+ */
+function decorateSlides(slides) {
+  const slideNames = [];
+  const numChildren = slides.length;
+  slides.forEach(($slide, i) => {
+    const title = $slide.querySelector('h1');
+    const label = title !== null ? `"${title.innerText}"` : `${i + 1} of ${numChildren}`;
+    slideNames.push(label);
+
+    $slide.setAttribute('role', 'tabpanel');
+    $slide.setAttribute('aria-roledescription', 'slide');
+    $slide.setAttribute('aria-label', `Slide ${label}`);
+    $slide.setAttribute('aria-hidden', (i !== 0).toString());
+  });
+  return slideNames;
+}
+
+/**
+ * Gets the index of the slide that is currently the active slide of the
+ * slideshow.
+ * @param {Array<HTMLElement>} slides The slides making up the slideshow.
+ * @returns {number} Index of the active slide.
+ */
+function getCurrentSlideIndex(slides) {
+  return slides.findIndex(($child) => $child.getAttribute('active') === 'true');
+}
+
+/**
+ * Decorates the slideshow's tab list with attributes and functionality required
+ * to make it fully accessible.
+ * @param {Slideshow} slideshow Information about the slideshow being decorated.
+ * @param {Array<string>} slideNames Display names of each of the slides in the
+ *  slideshow.
+ */
+function decorateTabList(slideshowInfo, slideNames) {
+  const {
+    slideshow,
+    slides,
+    tabList,
+  } = slideshowInfo;
+  tabList.setAttribute('role', 'tablist');
+
+  const listItems = tabList.querySelectorAll('li');
+  listItems.forEach((listItem, i) => {
+    listItem.setAttribute('role', 'tab');
+    listItem.setAttribute('aria-selected', (i === 0).toString());
+    listItem.setAttribute('aria-label', `Go to slide ${slideNames[i]}`);
+    listItem.addEventListener('click', () => {
+      const currentIndex = getCurrentSlideIndex(slides);
+      setSlideshowInteracted(slideshow, true);
+      changeSlide(slideshowInfo, currentIndex, i);
+    });
+  });
+}
+
+/**
+ * Adds auto rotating functionality to the slideshow.
+ * @param {Slideshow} slideshowInfo Information about the slideshow being
+ *  decorated.
+ */
+function applyAutoRotate(slideshowInfo) {
+  const {
+    slideshow,
+    slides,
+    rotateDelay = 5000,
+  } = slideshowInfo;
+  const numChildren = slides.length;
+
+  if (!rotateDelay) {
+    return;
+  }
+
+  // auto-play
+  const autoplayTimer = new ResumableInterval(rotateDelay, () => {
+    const currentIndex = getCurrentSlideIndex(slides);
+    if (!isSlideshowInteracted(slideshow)) {
+      changeSlide(slideshowInfo, currentIndex, (currentIndex + 1) % numChildren);
+    }
+  });
+  autoplayTimer.start();
+
+  slideshow.addEventListener('mouseenter', () => {
+    autoplayTimer.pause();
+  });
+
+  slideshow.addEventListener('mouseleave', () => {
+    autoplayTimer.resume();
+  });
+
+  slideshow.addEventListener('click', () => {
+    setSlideshowInteracted(slideshow, true);
+    autoplayTimer.pause();
+  });
+}
+
+/**
+ * Decorates a slideshow with aria and other accessibility-related attributes
+ * to ensure the slideshow meets accessibility requirements. The decoration
+ * will include:
+ * * Adding required aria properties.
+ * * Providing auto-rotation functionality, if specified.
+ * * Adding mouse and keyboard interactivity to the slideshow's tab list, if
+ *   specified.
+ * @param {Slideshow} slideshowInfo Information about the slideshow that
+ *  should be decorated with accessibility functionality.
+ * @returns {Promise} Resolves when all decoration is complete.
+ */
+export async function decorateSlideshowAria(slideshowInfo) {
+  decorateSlideshow(slideshowInfo.slideshow);
+  const slideNames = decorateSlides(slideshowInfo.slides);
+  if (slideshowInfo.tabList) {
+    decorateTabList(slideshowInfo, slideNames);
+  }
+  applyAutoRotate(slideshowInfo);
+}

--- a/blocks/slideshow/aria-slideshow.js
+++ b/blocks/slideshow/aria-slideshow.js
@@ -111,6 +111,16 @@ export function changeSlide(slideshowInfo, currentIndex, newIndex) {
 }
 
 /**
+ * Gets the index of the slide that is currently the active slide of the
+ * slideshow.
+ * @param {Array<HTMLElement>} slides The slides making up the slideshow.
+ * @returns {number} Index of the active slide.
+ */
+function getCurrentSlideIndex(slides) {
+  return slides.findIndex(($child) => $child.getAttribute('active') === 'true');
+}
+
+/**
  * Sets the currently active slide to a new index in the slideshow's
  * list of slides, and sets the tab at the new index as the newly
  * focused tab.
@@ -185,16 +195,6 @@ function decorateSlides(slides) {
 }
 
 /**
- * Gets the index of the slide that is currently the active slide of the
- * slideshow.
- * @param {Array<HTMLElement>} slides The slides making up the slideshow.
- * @returns {number} Index of the active slide.
- */
-function getCurrentSlideIndex(slides) {
-  return slides.findIndex(($child) => $child.getAttribute('active') === 'true');
-}
-
-/**
  * Decorates the slideshow's tab list with attributes and functionality required
  * to make it fully accessible.
  * @param {Slideshow} slideshow Information about the slideshow being decorated.
@@ -257,7 +257,6 @@ function applyAutoRotate(slideshowInfo) {
     slideshow,
     slides,
     rotateDelay = 5000,
-    tabList,
   } = slideshowInfo;
   const numChildren = slides.length;
 

--- a/blocks/slideshow/aria-slideshow.js
+++ b/blocks/slideshow/aria-slideshow.js
@@ -299,10 +299,33 @@ function applyAutoRotate(slideshowInfo) {
  * Decorates a slideshow with aria and other accessibility-related attributes
  * to ensure the slideshow meets accessibility requirements. The decoration
  * will include:
+ *
  * * Adding required aria properties.
  * * Providing auto-rotation functionality, if specified.
  * * Adding mouse and keyboard interactivity to the slideshow's tab list, if
  *   specified.
+ *
+ * Note that the decoration does _not_ include functionality for visibly
+ * changing the active slide, since individual slideshow implementations
+ * may differ in their construction. The scope of the decoration only
+ * includes updating a slide's aria attributes to indicate that it is
+ * currently the active slide.
+ *
+ * There are two ways to interact with the decorator's active slide
+ * functionality:
+ *
+ * 1. Listen for the event "hlx-slideshow-slide-changed" from the slideshow
+ *    element. This event is sent whenever the active slide has changed,
+ *    and callers of the decorate method should listen for this event
+ *    and visibly change the active slide. The event may be fired in
+ *    multiple scenarios, including auto rotations, keyboard interactions,
+ *    or mouse interactions.
+ * 2. Callers of the decorate method can actively change the current slide
+ *    using the changeSlide() method. For example, the decoration doesn't
+ *    include touch-related interactions, so if the caller needs to support
+ *    touch interactions, they can implement the required functionality and
+ *    call changeSlide() to update the active slide. Note that calling this
+ *    method will ultimately emit the event from item #1.
  * @param {Slideshow} slideshowInfo Information about the slideshow that
  *  should be decorated with accessibility functionality.
  * @returns {Promise} Resolves when all decoration is complete.

--- a/blocks/slideshow/slideshow.css
+++ b/blocks/slideshow/slideshow.css
@@ -1,6 +1,7 @@
 main .slideshow-container {
     padding: 0;
     position: relative;
+    overflow: hidden;
 
     --tab-bar-height: 30px;
 }
@@ -83,6 +84,7 @@ main .slideshow-container {
     width: 100%;
     display: flex;
     justify-content: center;
+    z-index: 1;
 }
 
 .tab-bar-container > ol {

--- a/blocks/slideshow/slideshow.js
+++ b/blocks/slideshow/slideshow.js
@@ -90,7 +90,7 @@ export default async function decorate($block) {
   $slidesContainer.classList.add('slides-container');
 
   const slides = [...$slidesContainer.children];
-  slides.forEach(($slide, i) => {
+  slides.forEach(($slide) => {
     $slide.classList.add('slide');
 
     const imgDiv = $slide.children[0];
@@ -114,7 +114,7 @@ export default async function decorate($block) {
     tabList.append($sliderNavBarButton);
   });
   $block.prepend($sliderNavBar);
-  $block.addEventListener(Events.SLIDE_CHANGED, function (e) {
+  $block.addEventListener(Events.SLIDE_CHANGED, (e) => {
     updateSlide(e.detail.currentIndex, e.detail.newIndex, $block);
   });
 

--- a/blocks/slideshow/slideshow.js
+++ b/blocks/slideshow/slideshow.js
@@ -1,6 +1,7 @@
 import { decorateIcons } from '../../scripts/lib-franklin.js';
 import { decorateResponsiveImages } from '../../scripts/scripts.js';
 import {
+  Events,
   decorateSlideshowAria,
   changeSlide,
 } from './aria-slideshow.js';
@@ -112,8 +113,8 @@ export default async function decorate($block) {
     $sliderNavBarButton.innerHTML = `<button class="control-button"><span class="icon icon-circle${i === 0 ? '-fill' : ''}" /></button>`;
     tabList.append($sliderNavBarButton);
   });
-  $block.append($sliderNavBar);
-  $block.addEventListener('hlx-slideshow-slide-changed', function (e) {
+  $block.prepend($sliderNavBar);
+  $block.addEventListener(Events.SLIDE_CHANGED, function (e) {
     updateSlide(e.detail.currentIndex, e.detail.newIndex, $block);
   });
 


### PR DESCRIPTION
Fix #88

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After: https://issue-88--petplace--hlxsites.hlx.page/

This PR introduces a new method that will decorate an _existing_ slideshow block with attributes and functionality to meet accessibility requirements. Some of the things provided are:

* Keyboard interaction support for slide selection tabs, if supported by the slideshow block.
* Auto rotation capabilities, if desired by the block.
* Full accessibility-related attribute decoration for all elements of a slideshow, including the slideshow's overall container, its tab selection elements (if provided), and the slides themselves.
* The decorator doesn't do the work of actually visibly changing the active slide, but it will decorate active/inactive slides appropriately, and provide a custom event that consumers can use to do that work.