### PR TITLE
feat: add a11y "skip to" links

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -325,7 +325,7 @@ function createA11yQuickNav(links = []) {
     const button = document.createElement('button');
     button.setAttribute('aria-label', l.label);
     button.href = `#${l.id}`;
-    button.innerHTML = `<span>${l.label}</span><span><span class="a11y-quicknav-button"><span class="a11y-quicknav-symbol">↵</span><span>ENTER</span></span></span>`;
+    button.innerHTML = `${l.label}`;
     button.addEventListener('click', (ev) => {
       ev.preventDefault();
       const el = document.getElementById(ev.currentTarget.href.split('#')[1]);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -338,7 +338,7 @@ function createA11yQuickNav(links = []) {
     const button = document.createElement('button');
     button.setAttribute('aria-label', l.label);
     button.href = `#${l.id}`;
-    button.innerHTML = `${l.label}`;
+    button.innerHTML = l.label;
     button.addEventListener('click', (ev) => {
       ev.preventDefault();
       const el = document.getElementById(ev.currentTarget.href.split('#')[1]);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -317,6 +317,27 @@ export function decorateScreenReaderOnly(container) {
     });
 }
 
+function createA11yQuickNav(links = []) {
+  const nav = document.createElement('nav');
+  nav.setAttribute('aria-label', 'Skip to specific locations on the page');
+  nav.classList.add('a11y-quicknav', 'sr-focusable');
+  links.forEach((l) => {
+    const button = document.createElement('button');
+    button.setAttribute('aria-label', l.label);
+    button.href = `#${l.id}`;
+    button.innerHTML = `<span>${l.label}</span><span><span class="a11y-quicknav-button"><span class="a11y-quicknav-symbol">↵</span><span>ENTER</span></span></span>`;
+    button.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      const el = document.getElementById(ev.currentTarget.href.split('#')[1]);
+      el.setAttribute('tabindex', 0);
+      el.focus();
+      el.addEventListener('focusout', () => { el.setAttribute('tabindex', -1); }, { once: true });
+    });
+    nav.append(button);
+  });
+  document.body.prepend(nav);
+}
+
 /**
  * Decorates the main element.
  * @param {Element} main The main element
@@ -438,27 +459,6 @@ export function decorateResponsiveImages(container, breakpoints = [440, 768]) {
   const responsiveImage = createResponsiveImage(pictures, breakpoints);
   container.innerHTML = '';
   container.append(responsiveImage);
-}
-
-function createA11yQuickNav(links = []) {
-  const nav = document.createElement('nav');
-  nav.setAttribute('aria-label', 'Skip to specific locations on the page');
-  nav.classList.add('a11y-quicknav', 'sr-focusable');
-  links.forEach((l) => {
-    const button = document.createElement('button');
-    button.setAttribute('aria-label', l.label);
-    button.href = `#${l.id}`;
-    button.innerHTML = `<span>${l.label}</span><span><span class="a11y-quicknav-button"><span class="a11y-quicknav-symbol">↵</span><span>ENTER</span></span></span>`;
-    button.addEventListener('click', (ev) => {
-      ev.preventDefault();
-      const el = document.getElementById(ev.currentTarget.href.split('#')[1]);
-      el.setAttribute('tabindex', 0);
-      el.focus();
-      el.addEventListener('focusout', () => { el.setAttribute('tabindex', -1); }, { once: true });
-    });
-    nav.append(button);
-  });
-  document.body.prepend(nav);
 }
 
 function getActiveSlide(block) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -478,46 +478,43 @@ a.sr-focusable:focus {
 }
 
 .a11y-quicknav:focus-within {
-  z-index: 1000;
+  z-index: 100;
   background: rgb(0 0 0 / 20%);
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .a11y-quicknav > button {
-  top: 40px;
-  z-index: 1000;
+  top: 30px;
+  z-index: 100;
   transition: top .22s ease;
   opacity: 0;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .a11y-quicknav > button, .a11y-quicknav > button:focus {
   position: absolute;
-  padding: 13px 20px;
+  padding: 18px 20px;
   border-radius: 50px;
   background-color: var(--background-color);
   line-height: 1;
   border: solid 3px rgb(19 110 248 / 80%);
   outline: solid 0 #639af9;
   box-shadow: 0 0 0 5px rgb(19 110 248 / 30%);
-  display: flex;
-  gap: 2rem;
-  align-items: center;
-  justify-content: center;
-  text-shadow: 0 0 #27272d;
   text-decoration: none;
-  color: #1f2533;
-  font-size: var(--body-font-size-default);
+  color: var(--text-color);
+  font-size: var(--body-font-size-s);
   transform: none;
   text-transform: unset;
 }
 
 .a11y-quicknav > button:focus {
   opacity: 1;
-  top: 20px;
-  z-index: 1001;
+  top: 10px;
+  z-index: 101;
 }
 
-.a11y-quicknav > button .a11y-quicknav-button {
-  font-size: var(--body-font-size-xxs);
+.a11y-quicknav button::after {
+  content: '↵ Enter';
   font-weight: 100;
   text-transform: uppercase;
   text-align: center;
@@ -526,15 +523,8 @@ a.sr-focusable:focus {
   background-color: #146ff8;
   padding: 5px 10px;
   color: var(--background-color);
-  margin: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.a11y-quicknav > button .a11y-quicknav-button .a11y-quicknav-symbol {
-  font-size: var(--body-font-size-default);
-  margin-right: .3rem;
+  margin: 0 0 0 1rem;
+  font-size: var(--body-font-size-xxs);
 }
 
 .slick-arrow {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -474,18 +474,19 @@ a.sr-focusable:focus {
   bottom: 0;
   right: 0;
   z-index: -1;
-  background-color: transparent;
+  background: transparent;
 }
 
 .a11y-quicknav:focus-within {
   z-index: 1000;
-  background-color: rgba(0, 0, 0, .2);
+  background: rgb(0 0 0 / 20%);
 }
 
-.a11y-quicknav > button:focus {
-  opacity: 1;
-  top: 20px;
-  z-index: 1001;
+.a11y-quicknav > button {
+  top: 40px;
+  z-index: 1000;
+  transition: top .22s ease;
+  opacity: 0;
 }
 
 .a11y-quicknav > button, .a11y-quicknav > button:focus {
@@ -494,9 +495,9 @@ a.sr-focusable:focus {
   border-radius: 50px;
   background-color: var(--background-color);
   line-height: 1;
-  border: solid 3px rgba(19,110,248,.8);
+  border: solid 3px rgb(19 110 248 / 80%);
   outline: solid 0 #639af9;
-  box-shadow: 0 0 0 5px rgba(19,110,248,.3);
+  box-shadow: 0 0 0 5px rgb(19 110 248 / 30%);
   display: flex;
   gap: 2rem;
   align-items: center;
@@ -509,11 +510,10 @@ a.sr-focusable:focus {
   text-transform: unset;
 }
 
-.a11y-quicknav > button {
-  top: 40px;
-  z-index: 1000;
-  transition: top .22s ease;
-  opacity: 0;
+.a11y-quicknav > button:focus {
+  opacity: 1;
+  top: 20px;
+  z-index: 1001;
 }
 
 .a11y-quicknav > button .a11y-quicknav-button {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -465,7 +465,77 @@ a.sr-focusable:focus {
   width: 1px;
 }
 
+.a11y-quicknav {
+  position: fixed;
+  margin: 0;
+  padding: 30px 0 0 20px;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  z-index: -1;
+  background-color: transparent;
+}
 
+.a11y-quicknav:focus-within {
+  z-index: 1000;
+  background-color: rgba(0, 0, 0, .2);
+}
+
+.a11y-quicknav > button:focus {
+  opacity: 1;
+  top: 20px;
+  z-index: 1001;
+}
+
+.a11y-quicknav > button, .a11y-quicknav > button:focus {
+  position: absolute;
+  padding: 13px 20px;
+  border-radius: 50px;
+  background-color: var(--background-color);
+  line-height: 1;
+  border: solid 3px rgba(19,110,248,.8);
+  outline: solid 0 #639af9;
+  box-shadow: 0 0 0 5px rgba(19,110,248,.3);
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+  justify-content: center;
+  text-shadow: 0 0 #27272d;
+  text-decoration: none;
+  color: #1f2533;
+  font-size: var(--body-font-size-default);
+  transform: none;
+  text-transform: unset;
+}
+
+.a11y-quicknav > button {
+  top: 40px;
+  z-index: 1000;
+  transition: top .22s ease;
+  opacity: 0;
+}
+
+.a11y-quicknav > button .a11y-quicknav-button {
+  font-size: var(--body-font-size-xxs);
+  font-weight: 100;
+  text-transform: uppercase;
+  text-align: center;
+  line-height: .9;
+  border-radius: 50px;
+  background-color: #146ff8;
+  padding: 5px 10px;
+  color: var(--background-color);
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.a11y-quicknav > button .a11y-quicknav-button .a11y-quicknav-symbol {
+  font-size: var(--body-font-size-default);
+  margin-right: .3rem;
+}
 
 .slick-arrow {
     position: absolute;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -534,10 +534,7 @@ a.sr-focusable:focus {
   position: fixed;
   margin: 0;
   padding: 30px 0 0 20px;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  right: 0;
+  inset: 0;
   z-index: -1;
   background: transparent;
 }


### PR DESCRIPTION
Fix #48 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After: https://issue-48--petplace--hlxsites.hlx.page/

This PR adds "skip to" buttons to the site. The buttons are hidden by default, but are revealed when they're focused. They're the first focusable elements on the page, so pressing the tab button will reveal them. Interacting with the buttons will focus the corresponding location in the page:

* "Skip to Content" will focus the `<main>` element.
* "Skip to Menu" will focus the first `li`'s `<a>` element in the page's primary navigation.
* "Skip to Footer" will focus the `<footer>` element.

All of the "Skip to" buttons are in a containing `<nav>` element, which is fixed, covers the entire content of the window, has a transparent background, and a `z-index` of -1. When anything in the `nav` is focused, it's brought to the front with a transparent black background; this is what provides the slightly darker "overlay" of the entire page whenever a "skip to" button is visible.