### PR TITLE
fix: hide sidekick when library is open

### DIFF
--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -19,6 +19,8 @@
         background-color: #ededed;
         height: 100%;
       }
+      
+      helix-sidekick { display: none }
     </style>
     <title>Sidekick Library</title>
   </head>


### PR DESCRIPTION
Forgot some css to hide the sidekick when the library is opened

Test URLs:

Before: https://main--petplace--hlxsites.hlx.page/
After: https://hide-sidekick--petplace--hlxsites.hlx.page/
