### PR TITLE
fix: tiles on homepage don't load if index isn't up-to-date

### DIFF
--- a/blocks/tiles/tiles.js
+++ b/blocks/tiles/tiles.js
@@ -39,6 +39,21 @@ export default async function decorate(block) {
       }
     }
 
+    const res = await fetch(path);
+    if (res.ok) {
+      const html = await res.text();
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      return {
+        path,
+        title: doc.querySelector('head > title').textContent,
+        description: doc.querySelector('head > meta[name="description"]').content,
+        image: doc.querySelector('head > meta[property="og:image"]').content,
+        imageAlt: doc.querySelector('head > meta[property="og:image:alt"]').content,
+        author: doc.querySelector('head > meta[property="og:image:alt"]').content,
+        date: new Date(doc.querySelector('head > meta[name="publication-date"]').content).getTime(),
+      };
+    }
+
     // eslint-disable-next-line no-console
     console.error(`No article in index found for ${path}`);
     return null;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After: https://tiles-fallback--petplace--hlxsites.hlx.page/
