### PR TITLE
fix: using slug to match instead of using name

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -159,7 +159,8 @@ export async function getCategoryByName(categoryName) {
   if (!categories) {
     return null;
   }
-  return categories.data.find((c) => c.Category.toLowerCase() === categoryName.toLowerCase());
+  const categorySlug = categoryName.toLowerCase().replace(/ /g, '-');
+  return categories.data.find((c) => c.Slug === categorySlug);
 }
 
 export async function getCategoryByKey(key, value) {


### PR DESCRIPTION
Fix #203 #204 #205

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.live/article/birds/general/what-to-do-if-your-bird-flies-the-coop
- After: https://issue-203--petplace--hlxsites.hlx.live/article/birds/general/what-to-do-if-your-bird-flies-the-coop

The reason cause the navigation error is the unsuccess matching the article with its category name, while using slug instead can solve it.
<img width="1344" alt="Screenshot 2023-07-01 at 1 15 13 AM" src="https://github.com/hlxsites/petplace/assets/105081458/d62e65fe-1ebe-4da3-8601-c4e13fe0c1f7">

After:
<img width="1351" alt="Screenshot 2023-07-05 at 10 42 01 AM" src="https://github.com/hlxsites/petplace/assets/105081458/e3734262-29d8-4c3f-aa47-46c360379464">


However, the searching algorithm is not very efficient, which may cause the delayed loading of the navigation bar. (I think it is fine, as it is at the bottom, but we do can improve it if needed. )