### PR TITLE
fix: sub-categories softnav not loading new articles properly

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -67,8 +67,8 @@ export default function decorate(block) {
           ul.querySelector('.skeleton').parentElement.replaceWith(await createCard(div));
         } else if (div.textContent.trim()) {
           ul.append(await createCard(div));
+          div.remove();
         }
-        div.remove();
       });
     });
   });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -62,6 +62,7 @@ export async function meterCalls(fn, wait = 200, max = 5) {
         if (!queue.length) {
           res();
           window.clearInterval(interval);
+          interval = null;
         }
       }, wait);
     } else {


### PR DESCRIPTION
This PR fixes a bunch of issues that lead to the cards not being updated when the sub-category buttons are clicked.

1. The placeholders got removed in the mutation observer when we only wanted to remove the actual content divs instead
2. The `meterCalls` function didn't clear its state properly and couldn't be called a second time once done, so the soft navigation was never updating the content
3. The generator function from `ffetch` kept firing after the soft navigation, essentially adding nodes from the previous filter to the current view, so added an `interrupt` method to it

Fix #231 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/article/category/pet-care/
- After: https://issue-231--petplace--hlxsites.hlx.page/article/category/pet-care/
