### PR TITLE
fix: speed up ads loading on desktop

### DIFF
--- a/blocks/ad/ad.css
+++ b/blocks/ad/ad.css
@@ -2,6 +2,7 @@
   margin: 0 auto;
   max-width: 100%;
   transition: min-height .3s ease;
+  will-change: min-height, height;
 }
 
 /* Skeleton loading styles */

--- a/blocks/ad/ad.js
+++ b/blocks/ad/ad.js
@@ -1,4 +1,4 @@
-import { getId, getJson } from '../../scripts/scripts.js';
+import { getId, getJson, isMobile } from '../../scripts/scripts.js';
 
 function addPrefetch(kind, url, as) {
   const linkEl = document.createElement('link');
@@ -10,10 +10,12 @@ function addPrefetch(kind, url, as) {
   document.head.append(linkEl);
 }
 
-addPrefetch('preconnect', 'https://securepubads.g.doubleclick.net');
-addPrefetch('preconnect', 'https://pagead2.googlesyndication.com');
-addPrefetch('preconnect', 'https://adservice.google.com');
-addPrefetch('preconnect', 'https://tpc.googlesyndication.com');
+if (isMobile()) {
+  addPrefetch('preconnect', 'https://securepubads.g.doubleclick.net');
+  addPrefetch('preconnect', 'https://pagead2.googlesyndication.com');
+  addPrefetch('preconnect', 'https://adservice.google.com');
+  addPrefetch('preconnect', 'https://tpc.googlesyndication.com');
+}
 
 /**
  * Retrieves information about the sites ads, which will ultimately be pulled

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,12 +1,15 @@
 // eslint-disable-next-line import/no-cycle
 import { sampleRUM } from './lib-franklin.js';
 // eslint-disable-next-line import/no-cycle
-import { loadScript } from './scripts.js';
+import { isMobile, loadScript } from './scripts.js';
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
 
 // add more delayed functionality here
+if (isMobile()) {
+  loadScript('https://securepubads.g.doubleclick.net/tag/js/gpt.js', () => {}, { async: '' });
+}
 
 window.PushlySDK = window.PushlySDK || [];
 function pushly(...args) {
@@ -15,5 +18,4 @@ function pushly(...args) {
 pushly('load', {
   domainKey: 'cfOCEQj2H76JJXktWCy3uK0OZCb1DMbfNUnq',
 });
-loadScript('https://securepubads.g.doubleclick.net/tag/js/gpt.js', () => {}, { async: '' });
 loadScript('https://cdn.p-n.io/pushly-sdk.min.js?domain_key=cfOCEQj2H76JJXktWCy3uK0OZCb1DMbfNUnq', null, { async: true });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -584,6 +584,9 @@ async function loadEager(doc) {
     document.body.classList.add('appear');
     await waitForLCP(LCP_BLOCKS);
   }
+  if (!isMobile()) {
+    loadScript('https://securepubads.g.doubleclick.net/tag/js/gpt.js', () => {}, { async: '' });
+  }
 }
 
 /**


### PR DESCRIPTION
Testing a hybrid approach where ads on desktop are loaded eagerly, and delayed on mobile to limit TBT there

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After: https://ads-hybrid--petplace--hlxsites.hlx.page/
