### PR TITLE
fix: optimize ffetch traversal queries

### DIFF
--- a/blocks/article-navigation/article-navigation.js
+++ b/blocks/article-navigation/article-navigation.js
@@ -65,6 +65,7 @@ async function createNavigation(block) {
   // Get all articles in that category
   const articles = ffetch('/article/query-index.json')
     .sheet('article')
+    .chunks(2000)
     .filter((article) => {
       const articleCategories = article.category !== '0'
         ? article.category.split(',').map((c) => c.trim().toLowerCase())

--- a/blocks/pagination/pagination.js
+++ b/blocks/pagination/pagination.js
@@ -11,7 +11,9 @@ function renderContent(block) {
   usp.set('page', page + 1);
   const nextParams = usp.toString();
 
-  const total = Math.ceil(Number(block.getAttribute('data-total')) / limit);
+  const total = Number.isNaN(Number(block.getAttribute('data-total')))
+    ? block.getAttribute('data-total')
+    : Math.ceil(Number(block.getAttribute('data-total')) / limit);
   block.innerHTML = `
     <nav aria-label="pagination">
       <ul>

--- a/blocks/tiles/tiles.js
+++ b/blocks/tiles/tiles.js
@@ -14,7 +14,7 @@ export default async function decorate(block) {
 
   if (!articles) {
     const data = await Promise.all([
-      fetch('/article/query-index.json?sheet=article&limit=2000'),
+      fetch('/article/query-index.json?sheet=article'),
       fetch('/article/query-index.json?sheet=breed'),
     ].map((fetch) => fetch.then((res) => res.json())));
     [articles, breed] = data.map((json) => json?.data);

--- a/templates/category-index/category-index.js
+++ b/templates/category-index/category-index.js
@@ -19,6 +19,7 @@ async function renderArticles(articles) {
     div.classList.add('skeleton');
     block.append(div);
   }
+  document.querySelector('.pagination').dataset.total = '...';
   articleLoadingPromise = await articles;
   // eslint-disable-next-line no-restricted-syntax
   for await (const article of articleLoadingPromise) {
@@ -44,6 +45,7 @@ async function getArticles() {
   const offset = (Number(usp.get('page') || 1) - 1) * limit;
   return ffetch('/article/query-index.json')
     .sheet('article')
+    .chunks(2000)
     .withTotal(true)
     .filter((article) => {
       const articleCategories = article.category !== '0'

--- a/templates/category-index/category-index.js
+++ b/templates/category-index/category-index.js
@@ -19,7 +19,7 @@ async function renderArticles(articles) {
     div.classList.add('skeleton');
     block.append(div);
   }
-  document.querySelector('.pagination').dataset.total = '...';
+  document.querySelector('.pagination').dataset.total = '…';
   articleLoadingPromise = await articles;
   // eslint-disable-next-line no-restricted-syntax
   for await (const article of articleLoadingPromise) {

--- a/templates/searchresults/searchresults.js
+++ b/templates/searchresults/searchresults.js
@@ -10,6 +10,7 @@ async function renderArticles(articles) {
     div.classList.add('skeleton');
     block.append(div);
   }
+  document.querySelector('.pagination').dataset.total = '…';
   const res = await articles;
   // eslint-disable-next-line no-restricted-syntax
   for await (const article of res) {

--- a/templates/searchresults/searchresults.js
+++ b/templates/searchresults/searchresults.js
@@ -41,6 +41,7 @@ async function getArticles() {
   }
   return ffetch('/article/query-index.json')
     .sheet(sheet)
+    .chunks(2000)
     .withTotal(true)
     .filter((article) => !query || `${article.description} ${article.title}`.toLowerCase().includes(query.toLowerCase()))
     .slice(offset, offset + limit);


### PR DESCRIPTION
Older articles that were published years/months ago, will tend to be at the end of the ffetch pagination. Hence when we compute the next/prev article navigation links, and also when we search or list articles in an "old" category, it takes a long while to traverse the 10K articles via the default 255 batch size that ffetch has.

Seeing that a 2K batch size takes ~1.2s, we can use that instead by default and still have good enough performance on the 1st page, but then greatly speed up the traversal of the 10K pages if needed


Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After: https://opt-ffetch-chunks--petplace--hlxsites.hlx.page/
