### PR TITLE
add template for puppy diaries index page.

### DIFF
--- a/templates/puppy-diaries-index/puppy-diaries-index.css
+++ b/templates/puppy-diaries-index/puppy-diaries-index.css
@@ -36,10 +36,6 @@
   vertical-align: middle;
 }
 
-.puppy-diaries-index .hero h1 {
-  display: none;
-}
-
 .puppy-diaries-index .blade .blade-body {
   grid-area: blade-body-area;
 }

--- a/templates/puppy-diaries-index/puppy-diaries-index.css
+++ b/templates/puppy-diaries-index/puppy-diaries-index.css
@@ -1,0 +1,91 @@
+.puppy-diaries-index .blade .blade-body h3 {
+  font-size: 1.5rem;
+  font-weight: 800;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.puppy-diaries-index .blade-wrapper {
+  margin-bottom: 3rem;
+}
+
+.puppy-diaries-index .blade .blade-body .button-container {
+  display: block;
+}
+
+.puppy-diaries-index .blade .blade-body .button {
+  width: 100%;
+  padding: 0.7rem 2.5rem;
+}
+
+.puppy-diaries-index .blade .blade-image img {
+  aspect-ratio: 1.43 / 1;
+  object-fit: cover;
+}
+
+.puppy-diaries-index .blade .blade-body .button::before {
+  display: inline-block;
+  content: '';
+  margin-right: .5rem;
+  height: 13px;
+  width: 29px;
+  background: var(--text-color-inverted);
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-mask: url('../../icons/arrow.svg') no-repeat center center;
+  mask: url('../../icons/arrow.svg') no-repeat center center;
+  vertical-align: middle;
+}
+
+.puppy-diaries-index .hero h1 {
+  display: none;
+}
+
+.puppy-diaries-index .blade .blade-body {
+  grid-area: blade-body-area;
+}
+
+.puppy-diaries-index .blade .blade-image {
+  grid-area: blade-image-area;
+}
+
+.puppy-diaries-index .blade > div {
+  display: grid;
+  grid-template:
+    "blade-image-area"
+    "blade-body-area";
+}
+
+@media (min-width: 768px) {
+  .puppy-diaries-index .blade .blade-body .button {
+    padding: 0.9375rem 2.5rem;
+    width: auto;
+  }
+
+  .puppy-diaries-index .blade .blade-image {
+    max-width: 480px;
+  }
+
+  .puppy-diaries-index .blade > div {
+    gap: 2rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .puppy-diaries-index .blade .blade-body h3 {
+    font-size: 2rem;
+  }
+
+  .puppy-diaries-index .blade > div {
+    display: flex;
+    grid-template: unset;
+    gap: 5rem;
+  }
+
+  .puppy-diaries-index main .hero > div {
+    max-width: unset;
+  }
+
+  .puppy-diaries-index main .hero picture {
+    position: unset;
+  }
+}

--- a/templates/puppy-diaries-index/puppy-diaries-index.js
+++ b/templates/puppy-diaries-index/puppy-diaries-index.js
@@ -1,4 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export
-export async function loadEager() {
-  // nothing here
+export async function loadLazy() {
+  const h1 = document.querySelector('.puppy-diaries-index .hero h1');
+  h1.classList.add('sr-only');
 }

--- a/templates/puppy-diaries-index/puppy-diaries-index.js
+++ b/templates/puppy-diaries-index/puppy-diaries-index.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/prefer-default-export
+export async function loadEager() {
+  // nothing here
+}


### PR DESCRIPTION
Fix #195 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/article/puppy-diaries/
- After: https://issue-195--petplace--hlxsites.hlx.page/drafts/frisbey/puppy-diaries-index

Adds a new template for the puppy diaries index page, and flesh out mobile, tablet, and desktop views.