### PR TITLE
fix: search results pagination according to upadated metercall

### DIFF
--- a/templates/searchresults/searchresults.js
+++ b/templates/searchresults/searchresults.js
@@ -35,9 +35,7 @@ async function renderArticles(articles) {
   // eslint-disable-next-line no-restricted-syntax
   for await (const article of res) {
     const div = createArticleDiv(article);
-    promises.push(
-      meterCalls(() => block.append(div)).then(() => removeSkeletons(block)),
-    );
+    promises.push(meterCalls(() => block.append(div)));
   }
   Promise.all(promises).then(() => {
     if (block.querySelectorAll('.skeleton').length === 25) {
@@ -46,6 +44,9 @@ async function renderArticles(articles) {
     removeSkeletons(block);
   });
   document.querySelector('.pagination').dataset.total = res.total();
+  window.requestAnimationFrame(() => {
+    block.querySelectorAll('.skeleton').forEach((sk) => sk.parentElement.remove());
+  });
 }
 
 async function getArticles() {

--- a/templates/searchresults/searchresults.js
+++ b/templates/searchresults/searchresults.js
@@ -40,10 +40,10 @@ async function renderArticles(articles) {
     );
   }
   Promise.all(promises).then(() => {
-    // This part will only be executed if the promises array is empty,
-    // indicating that no articles were found because the promises never resolve()
+    if (block.querySelectorAll('.skeleton').length === 25) {
+      noResultsHidePagination();
+    }
     removeSkeletons(block);
-    noResultsHidePagination();
   });
   document.querySelector('.pagination').dataset.total = res.total();
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After: https://searchresults--petplace--hlxsites.hlx.page/
