### PR TITLE
feat: add tag index pages

### DIFF
--- a/blocks/popular-tags/popular-tags.js
+++ b/blocks/popular-tags/popular-tags.js
@@ -1,5 +1,5 @@
 export default async function decorate(block) {
-  const resp = await fetch('/tags/popular-tags.plain.html');
+  const resp = await fetch('/fragments/popular-tags.plain.html');
   if (!resp.ok) {
     block.remove();
     return;

--- a/templates/category-index/category-index.js
+++ b/templates/category-index/category-index.js
@@ -110,10 +110,10 @@ function buildSidebar() {
   subCategories.setAttribute('aria-hidden', isMobile());
   section.append(subCategories);
 
-  // FIXME: const popularTags = buildBlock('popular-tags', { elems: [] });
-  // popularTags.id = id2;
-  // popularTags.setAttribute('aria-hidden', isMobile());
-  // section.append(popularTags);
+  const popularTags = buildBlock('popular-tags', { elems: [] });
+  popularTags.id = id2;
+  popularTags.setAttribute('aria-hidden', isMobile());
+  section.append(popularTags);
 
   filterToggle.addEventListener('click', () => {
     const isVisible = subCategories.getAttribute('aria-hidden') === 'false';
@@ -121,7 +121,7 @@ function buildSidebar() {
       filterToggle.dataset.mobileVisible = true;
     }
     subCategories.setAttribute('aria-hidden', isVisible);
-    // FIXME: popularTags.setAttribute('aria-hidden', isVisible);
+    popularTags.setAttribute('aria-hidden', isVisible);
   });
 
   window.addEventListener('resize', () => {
@@ -129,11 +129,11 @@ function buildSidebar() {
     if (!isVisible && !isMobile()) {
       filterToggle.disabled = true;
       subCategories.setAttribute('aria-hidden', false);
-      // FIXME: popularTags.setAttribute('aria-hidden', false);
+      popularTags.setAttribute('aria-hidden', false);
     } else if (isVisible && isMobile() && !filterToggle.dataset.mobileVisible) {
       filterToggle.disabled = false;
       subCategories.setAttribute('aria-hidden', true);
-      // FIXME: popularTags.setAttribute('aria-hidden', true);
+      popularTags.setAttribute('aria-hidden', true);
     }
   }, { passive: true });
 

--- a/templates/tag-index/tag-index.css
+++ b/templates/tag-index/tag-index.css
@@ -1,0 +1,128 @@
+
+.tag-index .hero {
+  box-sizing: border-box;
+  height: 62.5vw;
+  min-height: 0;
+  max-height: 326px;
+  padding: 0;
+  isolation: isolate;
+  display: flex;
+  flex-direction: column;
+  justify-content: end;
+}
+
+.tag-index .hero picture {
+  margin: 0;
+}
+
+.tag-index .hero img {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  object-fit: cover;
+}
+
+.tag-index .hero > div {
+  --bg-color: var(--color-purple-transparent);
+
+  max-width: none;
+  background: var(--bg-color);
+}
+
+.tag-index .hero > div > div {
+  max-width: 1392px;
+  margin: 0 auto;
+}
+
+.tag-index .hero h1 {
+  margin: 0;
+  padding: 2rem 1.5rem;
+  color: var(--text-color-inverted);
+  text-shadow: 2px 3px 5px rgb(0 0 0 / 50%);
+}
+
+.tag-index .sidebar {
+  padding: 1rem;
+  background-color: var(--background-color-dark);
+}
+
+.tag-index .sidebar > .default-content-wrapper:first-child {
+  text-align: center;
+}
+
+.tag-index .sidebar button[aria-controls] {
+  margin: 0;
+  background: none;
+  color: var(--highlight-color);
+  font-size: var(--body-font-size-l);
+}
+
+.tag-index .sidebar button[aria-controls]::before {
+  display: inline-block;
+  margin-right: 0.5rem;
+  content: "\2715";
+  font-size: 22px;
+  transform: rotate(45deg);
+  transition: transform 1s linear;
+}
+
+.tag-index .sidebar h2 {
+  position: relative;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--color-gray);
+  color: var(--text-color-inverted);
+  font-size: var(--heading-font-size-l);
+}
+
+.tag-index .sidebar h2::after {
+  position: absolute;
+  content: '';
+  display: block;
+  bottom: -2px;
+  width: 15%;
+  min-width: 100px;
+  max-width: 200px;
+  border-bottom: 3px solid var(--color-purple);
+}
+
+.tag-index .footer {
+  border-top: none;
+}
+
+@media (min-width: 1024px) {
+  .tag-index main {
+    display: grid;
+    grid-template:
+      'hero hero hero hero' min-content
+      '. sidebar content .' 1fr
+      '. sidebar pagination .' min-content / 1fr minmax(250px, 318px) minmax(750px, 1026px) 1fr;
+    gap: 0 1.5rem;
+  }
+
+  .tag-index .hero-container {
+    grid-area: hero;
+  }
+
+  .tag-index .sidebar {
+    grid-area: sidebar;
+    background: unset;
+    padding: 1rem 0;
+  }
+
+  .tag-index .pagination-container {
+    grid-area: pagination;
+  }
+
+  .tag-index .cards-container,
+  .tag-index .blog-cards-container {
+    grid-area: content;
+  }
+
+  .tag-index .sidebar h2 {
+    color: unset;
+  }
+
+  .tag-index .sidebar button[aria-controls] {
+    display: none;
+  }
+}

--- a/templates/tag-index/tag-index.js
+++ b/templates/tag-index/tag-index.js
@@ -1,0 +1,158 @@
+import ffetch from '../../scripts/ffetch.js';
+import {
+  buildBlock,
+  toClassName,
+} from '../../scripts/lib-franklin.js';
+import {
+  fetchAndCacheJson,
+  getId,
+  isMobile,
+  meterCalls,
+} from '../../scripts/scripts.js';
+
+const PAGINATE_ON = 12;
+
+async function getTagForUrl() {
+  const tags = await fetchAndCacheJson('/tags/tags.json');
+  const { pathname } = window.location;
+  return tags.find((tag) => tag.Path === pathname);
+}
+
+async function getArticles() {
+  const usp = new URLSearchParams(window.location.search);
+  const limit = usp.get('limit') || PAGINATE_ON;
+  const offset = (Number(usp.get('page') || 1) - 1) * limit;
+  const tag = await getTagForUrl();
+  const tagName = toClassName(tag.Name);
+  return ffetch('/article/query-index.json')
+    .sheet('article')
+    .withTotal(true)
+    .filter((article) => JSON.parse(article.tags).map((t) => toClassName(t)).includes(tagName))
+    .slice(offset, offset + limit);
+}
+
+let articleLoadingPromise;
+async function renderArticles(articles) {
+  const block = document.querySelector('.cards');
+  block.querySelectorAll('li').forEach((li) => li.remove());
+  for (let i = 0; i < PAGINATE_ON; i += 1) {
+    const div = document.createElement('div');
+    div.classList.add('skeleton');
+    block.append(div);
+  }
+  document.querySelector('.pagination').dataset.total = '…';
+  articleLoadingPromise = await articles;
+  let articleCount = 0;
+  const pagination = document.querySelector('.pagination.block');
+  // eslint-disable-next-line no-restricted-syntax
+  for await (const article of articleLoadingPromise) {
+    const div = document.createElement('div');
+    div.dataset.json = JSON.stringify(article);
+    articleCount += 1;
+    await meterCalls(() => block.append(div));
+    pagination.style.display = '';
+  }
+  if (articleCount === 0) {
+    const container = document.querySelector('.cards-container');
+    let noResults = container.querySelector('h2');
+    if (!document.querySelector('h2')) {
+      noResults = document.createElement('h2');
+      container.append(noResults);
+    }
+    noResults.innerText = 'No Articles Found';
+    if (pagination) {
+      pagination.style.display = 'none';
+    }
+  }
+  document.querySelector('.pagination').dataset.total = articleLoadingPromise.total();
+  window.requestAnimationFrame(() => {
+    block.querySelectorAll('.skeleton').forEach((sk) => sk.parentElement.remove());
+  });
+}
+
+function createTemplateBlock(main, blockName, elems = []) {
+  const section = document.createElement('div');
+
+  const block = buildBlock(blockName, { elems });
+  section.append(block);
+  main.append(section);
+  return block;
+}
+
+async function updateMetadata() {
+  const tag = await getTagForUrl();
+  if (!tag) {
+    throw new Error(404);
+  }
+  const { Name } = tag;
+  document.title = `${Name} | ${document.title}`;
+  document.head.querySelector('meta[property="og:title"]').content = document.title;
+  document.head.querySelector('meta[name="twitter:title"]').content = document.title;
+  const h1 = document.querySelector('h1');
+  h1.textContent = Name;
+  h1.id = toClassName(Name);
+}
+
+function buildSidebar() {
+  const section = document.createElement('div');
+  section.classList.add('sidebar');
+  section.setAttribute('role', 'complementary');
+
+  const id1 = getId();
+  const id2 = getId();
+  const filterToggle = document.createElement('button');
+  filterToggle.disabled = !isMobile();
+  filterToggle.setAttribute('aria-controls', `${id1} ${id2}`);
+  filterToggle.textContent = 'Filters';
+  section.append(filterToggle);
+
+  const subCategories = buildBlock('sub-categories', { elems: [] });
+  subCategories.id = id1;
+  subCategories.setAttribute('aria-hidden', isMobile());
+  section.append(subCategories);
+
+  const popularTags = buildBlock('popular-tags', { elems: [] });
+  popularTags.id = id2;
+  popularTags.setAttribute('aria-hidden', isMobile());
+  section.append(popularTags);
+
+  filterToggle.addEventListener('click', () => {
+    const isVisible = subCategories.getAttribute('aria-hidden') === 'false';
+    if (!isVisible) {
+      filterToggle.dataset.mobileVisible = true;
+    }
+    subCategories.setAttribute('aria-hidden', isVisible);
+    popularTags.setAttribute('aria-hidden', isVisible);
+  });
+
+  window.addEventListener('resize', () => {
+    const isVisible = subCategories.getAttribute('aria-hidden') === 'false';
+    if (!isVisible && !isMobile()) {
+      filterToggle.disabled = true;
+      subCategories.setAttribute('aria-hidden', false);
+      popularTags.setAttribute('aria-hidden', false);
+    } else if (isVisible && isMobile() && !filterToggle.dataset.mobileVisible) {
+      filterToggle.disabled = false;
+      subCategories.setAttribute('aria-hidden', true);
+      popularTags.setAttribute('aria-hidden', true);
+    }
+  }, { passive: true });
+
+  return section;
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export async function loadEager(main) {
+  await updateMetadata();
+  const h2 = document.createElement('h2');
+  h2.classList.add('sr-only');
+  h2.textContent = 'Articles';
+  const h1 = main.querySelector('h1');
+  h1.after(h2);
+  main.insertBefore(buildSidebar(), main.querySelector(':scope > div:nth-of-type(2)'));
+  createTemplateBlock(main, 'pagination');
+}
+
+export function loadLazy() {
+  renderArticles(getArticles());
+}


### PR DESCRIPTION
This is essentially a copy/paste of the category index template just leveraging the tags json endpoint and stripping away the custom image and color logic for the hero.

Fix #258 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.live/tags/dr-debras-posts
- After:
  - https://fix-tag-pages--petplace--hlxsites.hlx.live/tags/dr-debras-posts
  - https://fix-tag-pages--petplace--hlxsites.hlx.live/tags/pet-tips-for-dogs
