### PR TITLE
feat: add capability to disable martech via query parameter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,6 @@ Fix #<gh-issue-id>
 
 Test URLs:
 - Before: https://main--petplace--hlxsites.hlx.page/
-- After: https://<branch>--petplace--hlxsites.hlx.page/
+- After:
+  - https://<branch>--petplace--hlxsites.hlx.page/
+  - https://<branch>--petplace--hlxsites.hlx.page/?martech=off

--- a/blocks/ad/ad.js
+++ b/blocks/ad/ad.js
@@ -1,4 +1,9 @@
-import { fetchAndCacheJson, getId, isMobile } from '../../scripts/scripts.js';
+import {
+  fetchAndCacheJson,
+  getId,
+  isMartechDisabled,
+  isMobile,
+} from '../../scripts/scripts.js';
 
 function addPrefetch(kind, url, as) {
   const linkEl = document.createElement('link');
@@ -80,6 +85,12 @@ const loadedObserver = new MutationObserver((entries) => {
  * @param {HTMLElement} block Ad block to decorate.
  */
 export default async function decorate(block) {
+  if (isMartechDisabled) {
+    block.closest('.section').classList.remove('ad-container');
+    block.parentElement.remove();
+    return;
+  }
+
   window.googletag = window.googletag || { cmd: [] };
 
   if (!block.id) {

--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-cycle
 import { sampleRUM } from './lib-franklin.js';
 // eslint-disable-next-line import/no-cycle
-import { isMobile, loadScript } from './scripts.js';
+import { isMartechDisabled, isMobile, loadScript } from './scripts.js';
 
 // Core Web Vitals RUM collection
 sampleRUM('cwv');
@@ -37,21 +37,23 @@ async function loadAccessibeWidget() {
   }, { async: true });
 }
 
-// add more delayed functionality here
-if (isMobile() && document.querySelector('.block.ad')) {
-  loadScript('https://securepubads.g.doubleclick.net/tag/js/gpt.js', () => {}, { async: '' });
-}
-
-window.PushlySDK = window.PushlySDK || [];
 function pushly(...args) {
   window.PushlySDK.push(args);
 }
-pushly('load', {
-  domainKey: 'cfOCEQj2H76JJXktWCy3uK0OZCb1DMbfNUnq',
-});
-loadScript('https://cdn.p-n.io/pushly-sdk.min.js?domain_key=cfOCEQj2H76JJXktWCy3uK0OZCb1DMbfNUnq', null, { async: true });
 
-if (window.location.hostname === 'www.petplace.com'
-  || window.location.hostname.startsWith('main--petplace--hlxsites.hlx.')) {
-  loadAccessibeWidget();
+if (!isMartechDisabled) {
+  if (isMobile() && document.querySelector('.block.ad')) {
+    loadScript('https://securepubads.g.doubleclick.net/tag/js/gpt.js', () => {}, { async: '' });
+  }
+
+  window.PushlySDK = window.PushlySDK || [];
+  pushly('load', {
+    domainKey: 'cfOCEQj2H76JJXktWCy3uK0OZCb1DMbfNUnq',
+  });
+  loadScript('https://cdn.p-n.io/pushly-sdk.min.js?domain_key=cfOCEQj2H76JJXktWCy3uK0OZCb1DMbfNUnq', null, { async: true });
+
+  if (window.location.hostname === 'www.petplace.com'
+    || window.location.hostname.startsWith('main--petplace--hlxsites.hlx.')) {
+    loadAccessibeWidget();
+  }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -24,6 +24,8 @@ let templateModule;
 window.hlx.RUM_GENERATION = 'project-1'; // add your RUM generation information here
 window.hlx.cache = {};
 
+export const isMartechDisabled = new URLSearchParams(window.location.search).get('martech') === 'off';
+
 /**
  * Loads a script src and provides a callback that fires after
  * the script has loaded.
@@ -618,8 +620,10 @@ async function loadLazy(doc) {
   sampleRUM.observe(main.querySelectorAll('div[data-block-name]'));
   sampleRUM.observe(main.querySelectorAll('picture > img'));
 
-  integrateMartech();
-  initPartytown();
+  if (!isMartechDisabled) {
+    integrateMartech();
+    initPartytown();
+  }
 }
 
 /**


### PR DESCRIPTION
Add the capability to disable the martech stack via a query parameter (`?martech=off`), and update PR template to leverage this new flag so it's easier to measure the impact of code changes on the site.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://add-martech-flag--petplace--hlxsites.hlx.page/
  - https://add-martech-flag--petplace--hlxsites.hlx.page/?martech=off
