### PR TITLE
fix popular posts not appearing

### DIFF
--- a/blocks/popular-articles/popular-articles.js
+++ b/blocks/popular-articles/popular-articles.js
@@ -14,11 +14,13 @@ async function fetchArticleData(paths) {
 
     const catSlug = html.querySelector('meta[name="category"]').content;
     const catData = await getCategory(toClassName(catSlug));
+    const title = html.querySelector('h1').textContent;
+    const imageAlt = html.querySelector('meta[property="og:image:alt"]');
     return {
       image: html.querySelector('meta[property="og:image"]').content,
-      imageAlt: html.querySelector('meta[property="og:image:alt"]').content,
+      imageAlt: imageAlt ? imageAlt.content : title,
       path,
-      title: html.querySelector('h1').textContent,
+      title,
       category: catData.Category,
       categoryPath: catData.Path,
       author: html.querySelector('meta[name="author"]').content,


### PR DESCRIPTION
This PR updates the popular posts block so that it falls back to the page's title if a `og:image:alt` metadata property isn't available.

Fix #272

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://issue-272--petplace--hlxsites.hlx.page/article/cats/diseases-conditions-of-cats/everything-you-need-to-know-about-cat-licking
  - https://issue-272--petplace--hlxsites.hlx.page/article/cats/diseases-conditions-of-cats/everything-you-need-to-know-about-cat-licking?martech=off
