### PR TITLE
fix:  previous/next article doesn't exist in its own category

### DIFF
--- a/blocks/article-navigation/article-navigation.js
+++ b/blocks/article-navigation/article-navigation.js
@@ -109,17 +109,29 @@ async function createNavigation(block) {
     const index = parentCategories.findIndex((c) => c.Category === categoryInfo.Category);
 
     if (!previousArticle) {
-      previousCategoryInfo = parentCategories[(index - 1 + len) % len];
-      const previousCategoryArticles = getFilteredArticles(previousCategoryInfo);
-      const previousCategoryLastArticle = await previousCategoryArticles.last();
-      previousArticle = previousCategoryLastArticle;
+      // The current article is the first article in the category.
+      // Keep searching "previous" categories till one of them has articles,
+      // and use the last article in that category as the previous article.
+      for (let i = 1; i <= len && !previousArticle; i += 1) {
+        previousCategoryInfo = parentCategories[(index - i + len) % len];
+        const previousCategoryArticles = getFilteredArticles(previousCategoryInfo);
+        // eslint-disable-next-line no-await-in-loop
+        const previousCategoryLastArticle = await previousCategoryArticles.last();
+        previousArticle = previousCategoryLastArticle;
+      }
     }
 
     if (!nextArticle) {
-      nextCategoryInfo = parentCategories[(index + 1) % len];
-      const nextCategoryArticles = getFilteredArticles(nextCategoryInfo);
-      const nextCategoryFirstArticle = await nextCategoryArticles.first();
-      nextArticle = nextCategoryFirstArticle;
+      // The current article is the last article in the category.
+      // Keep searching "next" categories till one of them has articles,
+      // and use the first article in that category as the next article.
+      for (let i = 1; i <= len && !nextArticle; i += 1) {
+        nextCategoryInfo = parentCategories[(index + i) % len];
+        const nextCategoryArticles = getFilteredArticles(nextCategoryInfo);
+        // eslint-disable-next-line no-await-in-loop
+        const nextCategoryFirstArticle = await nextCategoryArticles.first();
+        nextArticle = nextCategoryFirstArticle;
+      }
     }
   }
 

--- a/scripts/ffetch.js
+++ b/scripts/ffetch.js
@@ -167,6 +167,14 @@ async function first(upstream) {
   return null;
 }
 
+async function last(upstream) {
+  let result = null;
+  for await (const entry of upstream) {
+    result = entry;
+  }
+  return result;
+}
+
 // Helper
 
 function assignOperations(generator, context) {
@@ -188,6 +196,7 @@ function assignOperations(generator, context) {
     chunks: chunks.bind(null, generator, context),
     all: all.bind(null, generator, context),
     first: first.bind(null, generator, context),
+    last: last.bind(null, generator, context),
     withFetch: withFetch.bind(null, generator, context),
     withHtmlParser: withHtmlParser.bind(null, generator, context),
     withTotal: withTotal.bind(null, generator, context),


### PR DESCRIPTION
When the previous/next article doesn't exist in its own category, using its parent/sibling category's article's last/first article as a fallback.

Fix #270 
<img width="666" alt="Screenshot 2023-07-28 at 10 33 02 AM" src="https://github.com/hlxsites/petplace/assets/105081458/e845c80a-721c-4617-a957-f4f7ba775ba0">
Case 1's example url:
https://issue-270--petplace--hlxsites.hlx.page/article/cats/pet-care/cat-care/senior-cat-care/tip-cats-considered-seniors
<img width="1401" alt="Screenshot 2023-07-28 at 10 38 22 AM" src="https://github.com/hlxsites/petplace/assets/105081458/5895bd2b-afee-4753-b89f-97fb2787203d">
Case 2's example url:
https://issue-270--petplace--hlxsites.hlx.page/article/birds/general/selecting-the-best-bird-feeder
![Screenshot 2023-07-28 at 10 37 51 AM](https://github.com/hlxsites/petplace/assets/105081458/2e409e28-4bea-4a36-9768-7f9f580bd55e)


Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/article/dogs/pet-care/160-littermate-names-for-dogs
- After:
  - https://issue-270--petplace--hlxsites.hlx.page/article/dogs/pet-care/160-littermate-names-for-dogs


