### PR TITLE
fix: Multi-category  leads to unsuccessfully fetch category information

### DIFF
--- a/blocks/article-navigation/article-navigation.js
+++ b/blocks/article-navigation/article-navigation.js
@@ -51,7 +51,7 @@ function createArticleDetails(block, key, categoryInfo, article) {
 }
 
 async function createNavigation(block) {
-  let category = getMetadata('category');
+  let category = getMetadata('category').split(',')[0]?.trim();
   if (!category) {
     // fall back on URL of a category hasn't been defined in the page's metadata
     category = await getCategory(window.location.pathname.split('/').slice(-2).shift());

--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -100,7 +100,7 @@ function convertToTitleCase(str) {
  * @returns {Promise<*[]>}
  * @param categorySlug snake case value of category
  */
-async function getBreadcrumbs(categorySlug) {
+async function getBreadcrumbs(categorySlugs) {
   const breadcrumbs = [];
 
   async function fetchSegmentData(slug) {
@@ -117,7 +117,7 @@ async function getBreadcrumbs(categorySlug) {
     }
   }
 
-  await fetchSegmentData(categorySlug);
+  await fetchSegmentData(categorySlugs[0]);
 
   return breadcrumbs.reverse();
 }
@@ -145,8 +145,8 @@ export async function loadEager(main) {
 
 export async function loadLazy(main) {
   const breadCrumbs = main.querySelector('.hero > div > div');
-  const categorySlug = toClassName(getMetadata('category'));
-  const crumbData = await getBreadcrumbs(categorySlug);
+  const categorySlugs = getMetadata('category').split(',').map((slug) => toClassName(slug.trim()));
+  const crumbData = await getBreadcrumbs(categorySlugs);
 
   const breadcrumbContainer = await createBreadCrumbs(crumbData);
   const breadcrumb = buildBlock('breadcrumb', { elems: [breadcrumbContainer] });

--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -100,7 +100,7 @@ function convertToTitleCase(str) {
  * @returns {Promise<*[]>}
  * @param categorySlug snake case value of category
  */
-async function getBreadcrumbs(categorySlugs) {
+async function getBreadcrumbs(categorySlug) {
   const breadcrumbs = [];
 
   async function fetchSegmentData(slug) {
@@ -117,7 +117,7 @@ async function getBreadcrumbs(categorySlugs) {
     }
   }
 
-  await fetchSegmentData(categorySlugs[0]);
+  await fetchSegmentData(categorySlug);
 
   return breadcrumbs.reverse();
 }
@@ -146,7 +146,7 @@ export async function loadEager(main) {
 export async function loadLazy(main) {
   const breadCrumbs = main.querySelector('.hero > div > div');
   const categorySlugs = getMetadata('category').split(',').map((slug) => toClassName(slug.trim()));
-  const crumbData = await getBreadcrumbs(categorySlugs);
+  const crumbData = await getBreadcrumbs(categorySlugs[0]);
 
   const breadcrumbContainer = await createBreadCrumbs(crumbData);
   const breadcrumb = buildBlock('breadcrumb', { elems: [breadcrumbContainer] });


### PR DESCRIPTION
For articles with multi-categories, we use the first category ( color, path...) to fetch info.
Fix #281 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/article/reptiles/general/ball-python-care
- After:
  - https://issue-281--petplace--hlxsites.hlx.page/article/reptiles/general/ball-python-care

### Example:
This article has categories: general, small-pet-health. We use general as its category for fetching color and path.
<img width="449" alt="Screenshot 2023-07-28 at 10 16 01 PM" src="https://github.com/hlxsites/petplace/assets/105081458/99aa20f9-28ab-4a82-8380-d53ab4fd0e04">
<img width="1103" alt="Screenshot 2023-07-28 at 10 16 10 PM" src="https://github.com/hlxsites/petplace/assets/105081458/00233aff-cf11-4152-b02e-f0f3a3763262">
