### PR TITLE
fix: previous/next article doesn't exist in its own category

### DIFF
--- a/blocks/article-navigation/article-navigation.js
+++ b/blocks/article-navigation/article-navigation.js
@@ -82,17 +82,35 @@ async function createNavigation(block) {
   let previousArticle = null;
   let nextArticle = null;
   let found = false;
+  let firstArticle = null;
+  let lastArticle = null;
   // eslint-disable-next-line no-restricted-syntax
   for await (const article of articles) {
-    if (found) {
-      nextArticle = article;
-      break;
+    if (!firstArticle) {
+      firstArticle = article;
     }
-    if (article.path === window.location.pathname) {
-      found = true;
+    lastArticle = article;
+    if (!found) {
+      if (article.path === window.location.pathname) {
+        found = true;
+      } else {
+        previousArticle = article;
+      }
     } else {
-      previousArticle = article;
+      if (!nextArticle) {
+        nextArticle = article;
+      }
+      if (previousArticle) {
+        break;
+      }
     }
+  }
+
+  if (!previousArticle) {
+    previousArticle = lastArticle;
+  }
+  if (!nextArticle) {
+    nextArticle = firstArticle;
   }
 
   if (previousArticle || nextArticle) {


### PR DESCRIPTION
Re-implement the prev/next, and record the first and last articles from search results. When the previous article is null, use the last article as the previous one. And when the next article is null, use the first article as the next.

Fix #275 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://issue-270-1--petplace--hlxsites.hlx.page/
  - https://issue-270-1--petplace--hlxsites.hlx.page/?martech=off
