### PR TITLE
fix: position of sidebar toggles on mobile/tablet

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -94,6 +94,14 @@ export function getId(prefix = 'hlx') {
  * @returns true if we are on a mobile, and false otherwise
  */
 export function isMobile() {
+  return window.innerWidth < 600;
+}
+
+/**
+ * A generic helper function that checks if we are in a tablet context based on viewport size
+ * @returns true if we are on a tablet, and false otherwise
+ */
+export function isTablet() {
   return window.innerWidth < 1024;
 }
 

--- a/templates/breed-index/breed-index.js
+++ b/templates/breed-index/breed-index.js
@@ -1,6 +1,6 @@
 import ffetch from '../../scripts/ffetch.js';
 import { buildBlock } from '../../scripts/lib-franklin.js';
-import { decorateResponsiveImages, getId, isMobile } from '../../scripts/scripts.js';
+import { decorateResponsiveImages, getId, isTablet } from '../../scripts/scripts.js';
 
 async function renderArticles(articles) {
   const block = document.querySelector('.cards');
@@ -36,14 +36,14 @@ function buildSidebar() {
 
   const id = getId();
   const filterToggle = document.createElement('button');
-  filterToggle.disabled = !isMobile();
+  filterToggle.disabled = !isTablet();
   filterToggle.setAttribute('aria-controls', `${id}`);
   filterToggle.textContent = 'Filters';
   section.append(filterToggle);
 
   const typeFilter = buildBlock('type-filters', { elems: [] });
   typeFilter.id = id;
-  typeFilter.setAttribute('aria-hidden', isMobile());
+  typeFilter.setAttribute('aria-hidden', isTablet());
   section.append(typeFilter);
 
   filterToggle.addEventListener('click', () => {
@@ -56,10 +56,10 @@ function buildSidebar() {
 
   window.addEventListener('resize', () => {
     const isVisible = filterToggle.getAttribute('aria-hidden') === 'false';
-    if (!isVisible && !isMobile()) {
+    if (!isVisible && !isTablet()) {
       filterToggle.disabled = true;
       filterToggle.setAttribute('aria-hidden', false);
-    } else if (isVisible && isMobile() && !filterToggle.dataset.mobileVisible) {
+    } else if (isVisible && isTablet() && !filterToggle.dataset.mobileVisible) {
       filterToggle.disabled = false;
       filterToggle.setAttribute('aria-hidden', true);
     }
@@ -78,7 +78,7 @@ function createTemplateBlock(main, blockName) {
 }
 
 export function loadEager(main) {
-  main.insertBefore(buildSidebar(), main.querySelector(':scope > div:nth-of-type(2)'));
+  main.insertBefore(buildSidebar(), main.querySelector(':scope > div:nth-of-type(1)'));
   const cards = createTemplateBlock(main, 'cards');
   cards.classList.add('breed');
   cards.dataset.limit = 6;

--- a/templates/breed-index/breed-index.js
+++ b/templates/breed-index/breed-index.js
@@ -78,7 +78,7 @@ function createTemplateBlock(main, blockName) {
 }
 
 export function loadEager(main) {
-  main.insertBefore(buildSidebar(), main.querySelector(':scope > div:nth-of-type(1)'));
+  main.insertBefore(buildSidebar(), main.querySelector(':scope > div:nth-of-type(2)'));
   const cards = createTemplateBlock(main, 'cards');
   cards.classList.add('breed');
   cards.dataset.limit = 6;

--- a/templates/category-index/category-index.js
+++ b/templates/category-index/category-index.js
@@ -4,7 +4,7 @@ import {
   getCategories,
   getCategory,
   getId,
-  isMobile,
+  isTablet,
   meterCalls,
 } from '../../scripts/scripts.js';
 // import { render as renderCategories } from '../../blocks/sub-categories/sub-categories.js';
@@ -100,19 +100,19 @@ function buildSidebar() {
   const id1 = getId();
   const id2 = getId();
   const filterToggle = document.createElement('button');
-  filterToggle.disabled = !isMobile();
+  filterToggle.disabled = !isTablet();
   filterToggle.setAttribute('aria-controls', `${id1} ${id2}`);
   filterToggle.textContent = 'Filters';
   section.append(filterToggle);
 
   const subCategories = buildBlock('sub-categories', { elems: [] });
   subCategories.id = id1;
-  subCategories.setAttribute('aria-hidden', isMobile());
+  subCategories.setAttribute('aria-hidden', isTablet());
   section.append(subCategories);
 
   const popularTags = buildBlock('popular-tags', { elems: [] });
   popularTags.id = id2;
-  popularTags.setAttribute('aria-hidden', isMobile());
+  popularTags.setAttribute('aria-hidden', isTablet());
   section.append(popularTags);
 
   filterToggle.addEventListener('click', () => {
@@ -126,11 +126,11 @@ function buildSidebar() {
 
   window.addEventListener('resize', () => {
     const isVisible = subCategories.getAttribute('aria-hidden') === 'false';
-    if (!isVisible && !isMobile()) {
+    if (!isVisible && !isTablet()) {
       filterToggle.disabled = true;
       subCategories.setAttribute('aria-hidden', false);
       popularTags.setAttribute('aria-hidden', false);
-    } else if (isVisible && isMobile() && !filterToggle.dataset.mobileVisible) {
+    } else if (isVisible && isTablet() && !filterToggle.dataset.mobileVisible) {
       filterToggle.disabled = false;
       subCategories.setAttribute('aria-hidden', true);
       popularTags.setAttribute('aria-hidden', true);
@@ -175,7 +175,7 @@ export async function loadEager(main) {
   h2.textContent = 'Articles';
   const h1 = main.querySelector('h1');
   h1.after(h2);
-  main.insertBefore(buildSidebar(), main.querySelector(':scope > div:nth-of-type(2)'));
+  main.insertBefore(buildSidebar(), main.querySelector(':scope > div:nth-of-type(1)'));
   createTemplateBlock(main, 'pagination');
   // eslint-disable-next-line no-restricted-globals
   const heroImg = await getCategoryImage(location.pathname);

--- a/templates/tag-index/tag-index.js
+++ b/templates/tag-index/tag-index.js
@@ -6,7 +6,7 @@ import {
 import {
   fetchAndCacheJson,
   getId,
-  isMobile,
+  isTablet,
   meterCalls,
 } from '../../scripts/scripts.js';
 
@@ -101,19 +101,19 @@ function buildSidebar() {
   const id1 = getId();
   const id2 = getId();
   const filterToggle = document.createElement('button');
-  filterToggle.disabled = !isMobile();
+  filterToggle.disabled = !isTablet();
   filterToggle.setAttribute('aria-controls', `${id1} ${id2}`);
   filterToggle.textContent = 'Filters';
   section.append(filterToggle);
 
   const subCategories = buildBlock('sub-categories', { elems: [] });
   subCategories.id = id1;
-  subCategories.setAttribute('aria-hidden', isMobile());
+  subCategories.setAttribute('aria-hidden', isTablet());
   section.append(subCategories);
 
   const popularTags = buildBlock('popular-tags', { elems: [] });
   popularTags.id = id2;
-  popularTags.setAttribute('aria-hidden', isMobile());
+  popularTags.setAttribute('aria-hidden', isTablet());
   section.append(popularTags);
 
   filterToggle.addEventListener('click', () => {
@@ -127,11 +127,11 @@ function buildSidebar() {
 
   window.addEventListener('resize', () => {
     const isVisible = subCategories.getAttribute('aria-hidden') === 'false';
-    if (!isVisible && !isMobile()) {
+    if (!isVisible && !isTablet()) {
       filterToggle.disabled = true;
       subCategories.setAttribute('aria-hidden', false);
       popularTags.setAttribute('aria-hidden', false);
-    } else if (isVisible && isMobile() && !filterToggle.dataset.mobileVisible) {
+    } else if (isVisible && isTablet() && !filterToggle.dataset.mobileVisible) {
       filterToggle.disabled = false;
       subCategories.setAttribute('aria-hidden', true);
       popularTags.setAttribute('aria-hidden', true);
@@ -149,7 +149,7 @@ export async function loadEager(main) {
   h2.textContent = 'Articles';
   const h1 = main.querySelector('h1');
   h1.after(h2);
-  main.insertBefore(buildSidebar(), main.querySelector(':scope > div:nth-of-type(2)'));
+  main.insertBefore(buildSidebar(), main.querySelector(':scope > div:nth-of-type(1)'));
   createTemplateBlock(main, 'pagination');
 }
 


### PR DESCRIPTION
Introduce a new tablet helper and fix the positioning of the sidebars on index pages as they appear below the cards at the moment

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://fix-sidebars--petplace--hlxsites.hlx.page/
  - https://fix-sidebars--petplace--hlxsites.hlx.page/?martech=off
