### PR TITLE
chore: try optimized font loading for smoother UX

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -631,6 +631,12 @@ function initPartytown() {
   import('./partytown/partytown.js');
 }
 
+function optimizedBatchLoading(promises) {
+  if (isMobile()) {
+    return promises.reduce((sequence, promise) => sequence.then(promise), Promise.resolve());
+  }
+  return Promise.all(promises);
+}
 /**
  * Loads everything that doesn't need to be delayed.
  * @param {Element} doc The container element
@@ -647,12 +653,14 @@ async function loadLazy(doc) {
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
-  await loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
-  loadFonts();
-  await loadHeader(doc.querySelector('header'));
   const footer = doc.querySelector('footer');
   footer.id = 'footer';
-  loadFooter(footer);
+  await optimizedBatchLoading([
+    loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`),
+    loadFonts(),
+    loadHeader(doc.querySelector('header')),
+    loadFooter(footer),
+  ]);
 
   // identify the first item in the menu
   const firstMenu = document.querySelector('.nav-wrapper .nav-sections ul li a');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -631,11 +631,14 @@ function initPartytown() {
   import('./partytown/partytown.js');
 }
 
-function optimizedBatchLoading(promises) {
+async function optimizedBatchLoading(promises) {
   if (isMobile()) {
-    return promises.reduce((sequence, promise) => sequence.then(promise), Promise.resolve());
+    return promises.reduce(
+      (sequence, promise) => sequence.then(() => promise()),
+      Promise.resolve(),
+    );
   }
-  return Promise.all(promises);
+  return Promise.all(promises.map((promise) => promise()));
 }
 /**
  * Loads everything that doesn't need to be delayed.
@@ -656,12 +659,11 @@ async function loadLazy(doc) {
   const footer = doc.querySelector('footer');
   footer.id = 'footer';
   await optimizedBatchLoading([
-    loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`),
-    loadFonts(),
-    loadHeader(doc.querySelector('header')),
-    loadFooter(footer),
+    () => loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`),
+    () => loadFonts(),
+    () => loadHeader(doc.querySelector('header')),
+    () => loadFooter(footer),
   ]);
-
   // identify the first item in the menu
   const firstMenu = document.querySelector('.nav-wrapper .nav-sections ul li a');
   firstMenu.id = 'menu';

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -647,13 +647,12 @@ async function loadLazy(doc) {
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
+  await loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
+  loadFonts();
   await loadHeader(doc.querySelector('header'));
   const footer = doc.querySelector('footer');
   footer.id = 'footer';
   loadFooter(footer);
-
-  await loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
-  loadFonts();
 
   // identify the first item in the menu
   const firstMenu = document.querySelector('.nav-wrapper .nav-sections ul li a');

--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -1,0 +1,39 @@
+/* latin */
+@font-face {
+  font-family: Raleway;
+  font-style: normal;
+  font-weight:  800;
+  font-display: swap;
+  src: url('https://fonts.gstatic.com/s/raleway/v28/1Ptug8zYS_SKggPNyC0IT4ttDfA.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* latin-ext */
+@font-face {
+  font-family: Raleway;
+  font-style: normal;
+  font-weight: 800;
+  font-display: swap;
+  src: url('https://fonts.gstatic.com/s/raleway/v28/1Ptug8zYS_SKggPNyCMIT4ttDfCmxA.woff2') format('woff2');
+  unicode-range: U+0100-02AF, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* latin */
+@font-face {
+  font-family: 'Libre Franklin';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://fonts.gstatic.com/s/librefranklin/v13/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhLsWkANDJTeFX1w.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* latin-ext */
+@font-face {
+  font-family: 'Libre Franklin';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('https://fonts.gstatic.com/s/librefranklin/v13/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhLsWkDtDJTeFX1-GE.woff2') format('woff2');
+  unicode-range: U+0100-02AF, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}

--- a/styles/lazy-styles.css
+++ b/styles/lazy-styles.css
@@ -1,46 +1,6 @@
 /* stylelint-disable no-descending-specificity */
 
-/* below the fold CSS goes here */
-
-/* latin */
-@font-face {
-  font-family: Raleway;
-  font-style: normal;
-  font-weight:  800;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/raleway/v28/1Ptug8zYS_SKggPNyC0IT4ttDfA.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-/* latin-ext */
-@font-face {
-  font-family: Raleway;
-  font-style: normal;
-  font-weight: 800;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/raleway/v28/1Ptug8zYS_SKggPNyCMIT4ttDfCmxA.woff2') format('woff2');
-  unicode-range: U+0100-02AF, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-
-/* latin */
-@font-face {
-  font-family: 'Libre Franklin';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/librefranklin/v13/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhLsWkANDJTeFX1w.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
-/* latin-ext */
-@font-face {
-  font-family: 'Libre Franklin';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('https://fonts.gstatic.com/s/librefranklin/v13/jizOREVItHgc8qDIbSTKq4XkRg8T88bjFuXOnduhLsWkDtDJTeFX1-GE.woff2') format('woff2');
-  unicode-range: U+0100-02AF, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
+/* add global styles that can be loaded post LCP here */
 
 .nav-sidebar [role="dialog"] {
   position: fixed;


### PR DESCRIPTION
Track if fonts have previously been loaded and cached by the browser so we can speed up the loading on subsequent visits. If the browser cache is not disabled, this should remove the flickering from the font swap when you navigate across pages.

THis also introduces an optimized way to load multiple requests for mobile vs. desktop so we don't impact the score in a negative way. This ultimately helps improve LCP, TTI and SI scores.

Fix #274 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://issue-274c--petplace--hlxsites.hlx.page/
  - https://issue-274c--petplace--hlxsites.hlx.page/?martech=off
