### PR TITLE
fix: flicker of hero block on article pages

### DIFF
--- a/templates/article-page/article-page.css
+++ b/templates/article-page/article-page.css
@@ -69,6 +69,7 @@
 .article-page .breadcrumb {
   position: absolute;
   top: 1rem;
+  height: 50px;
 }
 
 .article-page .breadcrumb .icon-chevron {

--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -150,9 +150,9 @@ export async function loadLazy(main) {
 
   const breadcrumbContainer = await createBreadCrumbs(crumbData);
   const breadcrumb = buildBlock('breadcrumb', { elems: [breadcrumbContainer] });
-  breadCrumbs.style.visibility = 'hidden';
+  breadcrumb.style.visibility = 'hidden';
   breadCrumbs.append(breadcrumb);
   decorateBlock(breadcrumb);
   await loadBlock(breadcrumb);
-  breadCrumbs.style.visibility = '';
+  breadcrumb.style.visibility = '';
 }


### PR DESCRIPTION
The current hero block on article pages flickers out of visibility during the breadcrumb load. This was initiall done to hide some CLS, but we can have a cleaner alternative to this.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://fix-hero-flicker--petplace--hlxsites.hlx.page/article/general/pet-health/national-immunization-awareness-month
  - https://fix-hero-flicker--petplace--hlxsites.hlx.page/article/general/pet-health/national-immunization-awareness-month?martech=off