### PR TITLE
feat: implement get-pet-insurance-now page

### DIFF
--- a/blocks/blade/blade.css
+++ b/blocks/blade/blade.css
@@ -38,10 +38,6 @@
     width: 100%;
 }
 
-.blade .blade-body p:not(:last-child) {
-    margin-bottom: 0.75em;
-}
-
 .blade .blade-body :is(h3, h4) {
     margin-top: 0;
     font-family: var(--heading-font-family);
@@ -58,6 +54,10 @@
 
 .blade .blade-body p {
     font-size: var(--body-font-size-m);
+}
+
+.blade .blade-body p:not(:last-child) {
+    margin-bottom: 0.75em;
 }
 
 .blade a:not(.button):any-link {

--- a/blocks/blade/blade.css
+++ b/blocks/blade/blade.css
@@ -5,8 +5,8 @@
 
 .blade h2 {
     margin-top: 0;
-}  
-  
+}
+
 .blade > div {
     display: flex;
     flex-direction: column;
@@ -36,6 +36,10 @@
     position: relative;
     box-sizing: border-box;
     width: 100%;
+}
+
+.blade .blade-body p {
+    margin-bottom: 0.75em;
 }
 
 .blade .blade-body :is(h3, h4) {

--- a/blocks/blade/blade.css
+++ b/blocks/blade/blade.css
@@ -38,7 +38,7 @@
     width: 100%;
 }
 
-.blade .blade-body p {
+.blade .blade-body p:not(:last-child) {
     margin-bottom: 0.75em;
 }
 

--- a/blocks/pet-insurance-quote/pet-insurance-quote.css
+++ b/blocks/pet-insurance-quote/pet-insurance-quote.css
@@ -2,19 +2,19 @@
   background-color: var(--background-color-dark);
 }
 
-.pet-insurance-quote > div > div {
-  color: var(--text-color-inverted);
-  font-size: var(--body-font-size-xl);
-  font-weight: 800;
-  font-family: var(--heading-font-family);
-}
-
 .pet-insurance-quote > div {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 1rem;
+}
+
+.pet-insurance-quote > div > div {
+  color: var(--text-color-inverted);
+  font-size: var(--body-font-size-xl);
+  font-weight: 800;
+  font-family: var(--heading-font-family);
 }
 
 @media (min-width: 1024px) {

--- a/blocks/pet-insurance-quote/pet-insurance-quote.css
+++ b/blocks/pet-insurance-quote/pet-insurance-quote.css
@@ -16,3 +16,20 @@
   justify-content: center;
   padding: 1rem;
 }
+
+@media (min-width: 1024px) {
+  .pet-insurance-quote {
+    border: 1px solid var(--background-color-dark);
+    border-radius: 10px;
+  }
+
+  .pet-insurance-quote > div > div::after {
+    content: '→';
+    display: inline-block;
+    padding: 0 1.5rem;
+  }
+
+  .pet-insurance-quote > div {
+    flex-direction: row;
+  }
+}

--- a/blocks/pet-insurance-quote/pet-insurance-quote.css
+++ b/blocks/pet-insurance-quote/pet-insurance-quote.css
@@ -1,1 +1,18 @@
-/* Nothing here yet */
+.pet-insurance-quote {
+  background-color: var(--background-color-dark);
+}
+
+.pet-insurance-quote > div > div {
+  color: var(--text-color-inverted);
+  font-size: var(--body-font-size-xl);
+  font-weight: 800;
+  font-family: var(--heading-font-family);
+}
+
+.pet-insurance-quote > div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}

--- a/blocks/pet-insurance-quote/pet-insurance-quote.js
+++ b/blocks/pet-insurance-quote/pet-insurance-quote.js
@@ -1,4 +1,10 @@
 export default function decorate(block) {
-  // Nothing here yet
-  block.innerHTML = '';
+  const a = document.createElement('a');
+  a.classList.add('button', 'primary');
+  a.href = 'https://www.petpartners.com/enroll?p=PPFB2020';
+
+  const buttonCell = block.children[0].children[1];
+  a.innerText = buttonCell.innerText;
+  buttonCell.remove();
+  block.children[0].append(a);
 }


### PR DESCRIPTION
Implements the get-pet-insurance-now page, which consists of some minor margin improvements to the blade block (so that it can support text with multiple paragraphs), and implementing the `pet-insurance-quote` block.

The `pet-insurance-quote` block authoring looks like this:

![Screenshot 2023-08-08 at 4 06 35 PM](https://github.com/hlxsites/petplace/assets/5108740/b0f5322b-d770-468e-81ea-fe89681f1d88)

When rendered, the first cell becomes the label, and the second cell becomes the button:

![Screenshot 2023-08-08 at 4 07 28 PM](https://github.com/hlxsites/petplace/assets/5108740/9d9b8b96-1518-4fcd-b8ee-71072779e90d)

![Screenshot 2023-08-08 at 4 07 50 PM](https://github.com/hlxsites/petplace/assets/5108740/c943b3a0-47a7-45b1-9075-12059e10a447)

Fix #291 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/frisbey/drafts/get-pet-insurance-now
- After:
  - https://issue-291--petplace--hlxsites.hlx.page/frisbey/drafts/get-pet-insurance-now
  - https://issue-291--petplace--hlxsites.hlx.page/frisbey/drafts/get-pet-insurance-now?martech=off
