### PR TITLE
fix: cls on article pages

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -358,9 +358,8 @@ main blockquote p::after {
 }
 
 main img {
+  display: block;
   max-width: 100%;
-  width: auto;
-  height: auto;
 }
 
 main iframe[src*="youtube.com"] {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -360,6 +360,7 @@ main blockquote p::after {
 main img {
   display: block;
   max-width: 100%;
+  height: auto;
 }
 
 main iframe[src*="youtube.com"] {

--- a/templates/article-page/article-page.css
+++ b/templates/article-page/article-page.css
@@ -3,9 +3,9 @@
   grid-template:
     "hero"
     "author" minmax(181px, min-content)
+    "social" minmax(115px, min-content)
     "ad"
     "insurance"
-    "social" minmax(115px, min-content)
     "article"
     "article-footer"
     "paws-up"
@@ -28,10 +28,6 @@
 .article-page h3 {
   font-size:1.375rem;
   font-weight: 800;
-}
-
-.article-page .default-content-wrapper img {
-  max-width: 100%;
 }
 
 .article-page .footer {
@@ -145,10 +141,10 @@
     grid-template:
       "hero hero hero hero hero" min-content
       ". article .. author ." min-content
-      ". article .. ad ." min-content
+      ". article .. social ." min-content
+      ". article .. ad ." 1fr
       ". article .. insurance ." min-content
       ". article .. paws-up ." min-content
-      ". article .. social ." 1fr
       "popular popular popular popular popular" min-content
       "article-navigation article-navigation article-navigation article-navigation article-navigation" min-content
       / minmax(1rem, 1fr) minmax(420px, 720px) minmax(1rem, 64px) 300px minmax(1rem, 1fr);
@@ -204,6 +200,7 @@
 
   .article-page .article-author-container {
     padding-top: 1rem;
+    padding-bottom: 0;
   }
 
   .article-page .category-link-btn {

--- a/templates/article-page/article-page.css
+++ b/templates/article-page/article-page.css
@@ -3,9 +3,9 @@
   grid-template:
     "hero"
     "author" minmax(181px, min-content)
-    "social" minmax(115px, min-content)
     "ad"
     "insurance"
+    "social" minmax(115px, min-content)
     "article"
     "article-footer"
     "paws-up"
@@ -141,10 +141,10 @@
     grid-template:
       "hero hero hero hero hero" min-content
       ". article .. author ." min-content
-      ". article .. social ." min-content
-      ". article .. ad ." 1fr
+      ". article .. ad ." min-content
       ". article .. insurance ." min-content
       ". article .. paws-up ." min-content
+      ". article .. social ." 1fr
       "popular popular popular popular popular" min-content
       "article-navigation article-navigation article-navigation article-navigation article-navigation" min-content
       / minmax(1rem, 1fr) minmax(420px, 720px) minmax(1rem, 64px) 300px minmax(1rem, 1fr);
@@ -200,7 +200,6 @@
 
   .article-page .article-author-container {
     padding-top: 1rem;
-    padding-bottom: 0;
   }
 
   .article-page .category-link-btn {

--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -129,8 +129,8 @@ async function getBreadcrumbs(categorySlug) {
 // eslint-disable-next-line import/prefer-default-export
 export async function loadEager(main) {
   createTemplateBlock(main, 'article-author');
-  createTemplateBlock(main, 'social-share');
   createAutoBlockSection(main, 'ad', 'ad');
+  createTemplateBlock(main, 'social-share');
   createTemplateBlock(main, 'popular-articles');
   createTemplateBlock(main, 'article-navigation');
   createTableOfContents(main);

--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -129,8 +129,8 @@ async function getBreadcrumbs(categorySlug) {
 // eslint-disable-next-line import/prefer-default-export
 export async function loadEager(main) {
   createTemplateBlock(main, 'article-author');
-  createAutoBlockSection(main, 'ad', 'ad');
   createTemplateBlock(main, 'social-share');
+  createAutoBlockSection(main, 'ad', 'ad');
   createTemplateBlock(main, 'popular-articles');
   createTemplateBlock(main, 'article-navigation');
   createTableOfContents(main);


### PR DESCRIPTION
Fixing minor CLS issue for content images as the height/width auto actually bypasses the hardcoded default sizes and hence creates CLS when they are loaded.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://fix-article-cls--petplace--hlxsites.hlx.page/?martech=off
  - https://fix-article-cls--petplace--hlxsites.hlx.page/article/general/pet-care/microchipping-protection-if-pets-get-lost?martech=off
  - https://fix-article-cls--petplace--hlxsites.hlx.page/article/category/pet-care/?martech=off
