### PR TITLE
fix: only show pet-insurance-quote block when it has content

### DIFF
--- a/blocks/pet-insurance-quote/pet-insurance-quote.js
+++ b/blocks/pet-insurance-quote/pet-insurance-quote.js
@@ -1,4 +1,11 @@
 export default function decorate(block) {
+  // for backward compatibility, there are some pet insurance blocks in existing
+  // pages that don't have content. Continue showing nothing for those cases
+  if (!String(block.innerText).trim()) {
+    block.remove();
+    return;
+  }
+
   const a = document.createElement('a');
   a.classList.add('button', 'primary');
   a.href = 'https://www.petpartners.com/enroll?p=PPFB2020';


### PR DESCRIPTION
Ensures pet-insurance-quote blocks without content continue to be invisible.

Fix #291 

Test URLs:
- Before:
  - https://main--petplace--hlxsites.hlx.page/drafts/frisbey/get-pet-insurance-now
  - https://main--petplace--hlxsites.hlx.page/article/dogs/pet-care/is-it-safe-to-dye-my-dogs-hair
- After:
  - https://issue-291-fix--petplace--hlxsites.hlx.page/drafts/frisbey/get-pet-insurance-now
  - https://issue-291-fix--petplace--hlxsites.hlx.page/drafts/frisbey/get-pet-insurance-now?martech=off
  - https://issue-291-fix--petplace--hlxsites.hlx.page/article/dogs/pet-care/is-it-safe-to-dye-my-dogs-hair
  - https://issue-291-fix--petplace--hlxsites.hlx.page/article/dogs/pet-care/is-it-safe-to-dye-my-dogs-hair?martech=off
