### PR TITLE
feat: fixing redirects for known urls

### DIFF
--- a/404.html
+++ b/404.html
@@ -6,6 +6,36 @@
   <script type="text/javascript">
     window.isErrorPage = true;
     window.errorCode = '404';
+
+    // Trying to fix URLs producing 404s
+    if (document.referrer) {
+      const { origin, pathname } = new URL(document.referrer);
+      if (origin !== window.location.origin) {
+        return;
+      }
+
+      // Redirect old pagination URLs
+      const [,page] = window.location.pathname.match(/\/page\/(\d+)\/$/) || [];
+      if (page) {
+        window.location.replace(window.location.pathname.replace(/\/page\/(\d+)\/$/, `?page=${page}`));
+        return;
+      }
+
+      // Try to identify vanity URLs
+      const tokens = pathname.split('/').filter((token) => !!token);
+      if (tokens.length === 1) {
+        try {
+          const resp = await fetch('/article/query-index.json?sheet=article&limit=-1');
+          const json = await resp.json();
+          const article = json.data.find((article) => article.path.endsWith(tokens[0]));
+          if (article) {
+            window.location.replace(article);
+          }
+        } catch (err) {
+          // Nothing to do here
+        }
+      }
+    }
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="Page not found">
@@ -29,7 +59,7 @@
     });
 
     sampleRUM('404', { source: document.referrer, target: window.location.href });
-    window.location.replace('/');
+    // window.location.replace('/');
   </script>
   <link rel="stylesheet" href="/styles/styles.css">
   <style>

--- a/404.html
+++ b/404.html
@@ -14,7 +14,6 @@
       const [,page] = window.location.pathname.match(/\/page\/(\d+)\/$/) || [];
       if (page) {
         window.location.replace(window.location.pathname.replace(/\/page\/(\d+)\/$/, `?page=${page}`));
-        return;
       }
 
       // Try to identify vanity URLs

--- a/404.html
+++ b/404.html
@@ -25,10 +25,10 @@
     }
 
     // Redirect invalid pagination URLs
-    [,page] = pathname.match(/\/(\d+)\/$/) || [];
+    [,page] = pathname.match(/\/(\d+)\/?$/) || [];
     if (!redirecting && page) {
       redirecting = true;
-      window.location.replace(pathname.replace(/\/(\d+)\/$/, ''));
+      window.location.replace(pathname.replace(/\/(\d+)\/?$/, ''));
     }
 
     // Try to identify vanity URLs

--- a/404.html
+++ b/404.html
@@ -24,7 +24,7 @@
         .then((json) => {
           const article = json.data.find((article) => article.path.endsWith(tokens[0]));
           if (article) {
-            window.location.replace(article);
+            window.location.replace(article.path);
           }
         });
     }

--- a/404.html
+++ b/404.html
@@ -51,7 +51,7 @@
     });
 
     sampleRUM('404', { source: document.referrer, target: window.location.href });
-    // window.location.replace('/');
+    window.location.replace('/');
   </script>
   <link rel="stylesheet" href="/styles/styles.css">
   <style>

--- a/404.html
+++ b/404.html
@@ -18,10 +18,17 @@
 
     // Redirect old pagination URLs
     const { pathname } = window.location;
-    const [,page] = pathname.match(/\/page\/(\d+)\/$/) || [];
+    let [,page] = pathname.match(/\/page\/(\d+)\/$/) || [];
     if (page) {
       redirecting = true;
       window.location.replace(pathname.replace(/\/page\/(\d+)\/$/, `?page=${page}`));
+    }
+
+    // Redirect invalid pagination URLs
+    [,page] = pathname.match(/\/(\d+)\/$/) || [];
+    if (!redirecting && page) {
+      redirecting = true;
+      window.location.replace(pathname.replace(/\/(\d+)\/$/, ''));
     }
 
     // Try to identify vanity URLs

--- a/404.html
+++ b/404.html
@@ -8,26 +8,24 @@
     window.errorCode = '404';
 
     // Trying to fix URLs producing 404s
-    const { origin, pathname } = document.referrer ? new URL(document.referrer) : {};
-    if (origin === window.location.origin) {
-      // Redirect old pagination URLs
-      const [,page] = window.location.pathname.match(/\/page\/(\d+)\/$/) || [];
-      if (page) {
-        window.location.replace(window.location.pathname.replace(/\/page\/(\d+)\/$/, `?page=${page}`));
-      }
 
-      // Try to identify vanity URLs
-      const tokens = pathname.split('/').filter((token) => !!token);
-      if (tokens.length === 1) {
-        const resp = fetch('/article/query-index.json?sheet=article&limit=-1')
-          .then((resp) => resp.json())
-          .then((json) => {
-            const article = json.data.find((article) => article.path.endsWith(tokens[0]));
-            if (article) {
-              window.location.replace(article);
-            }
-          });
-      }
+    // Redirect old pagination URLs
+    const [,page] = window.location.pathname.match(/\/page\/(\d+)\/$/) || [];
+    if (page) {
+      window.location.replace(window.location.pathname.replace(/\/page\/(\d+)\/$/, `?page=${page}`));
+    }
+
+    // Try to identify vanity URLs
+    const tokens = pathname.split('/').filter((token) => !!token);
+    if (tokens.length === 1) {
+      const resp = fetch('/article/query-index.json?sheet=article&limit=-1')
+        .then((resp) => resp.json())
+        .then((json) => {
+          const article = json.data.find((article) => article.path.endsWith(tokens[0]));
+          if (article) {
+            window.location.replace(article);
+          }
+        });
     }
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/404.html
+++ b/404.html
@@ -19,14 +19,14 @@
     // Try to identify vanity URLs
     const tokens = pathname.split('/').filter((token) => !!token);
     if (tokens.length === 1) {
-      const resp = fetch('/article/query-index.json?sheet=article&limit=-1')
-        .then((resp) => resp.json())
-        .then((json) => {
-          const article = json.data.find((article) => article.path.endsWith(tokens[0]));
+      (async function() {
+        const resp = await fetch('/article/query-index.json?sheet=article&limit=-1');
+        const json = await resp.json();
+        const article = json.data.find((article) => article.path.endsWith(tokens[0]));
           if (article) {
             window.location.replace(article.path);
           }
-        });
+      })();
     }
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/404.html
+++ b/404.html
@@ -19,16 +19,14 @@
       // Try to identify vanity URLs
       const tokens = pathname.split('/').filter((token) => !!token);
       if (tokens.length === 1) {
-        try {
-          const resp = await fetch('/article/query-index.json?sheet=article&limit=-1');
-          const json = await resp.json();
-          const article = json.data.find((article) => article.path.endsWith(tokens[0]));
-          if (article) {
-            window.location.replace(article);
-          }
-        } catch (err) {
-          // Nothing to do here
-        }
+        const resp = fetch('/article/query-index.json?sheet=article&limit=-1')
+          .then((resp) => resp.json())
+          .then((json) => {
+            const article = json.data.find((article) => article.path.endsWith(tokens[0]));
+            if (article) {
+              window.location.replace(article);
+            }
+          });
       }
     }
   </script>

--- a/404.html
+++ b/404.html
@@ -8,12 +8,8 @@
     window.errorCode = '404';
 
     // Trying to fix URLs producing 404s
-    if (document.referrer) {
-      const { origin, pathname } = new URL(document.referrer);
-      if (origin !== window.location.origin) {
-        return;
-      }
-
+    const { origin, pathname } = document.referrer ? new URL(document.referrer) : {};
+    if (origin === window.location.origin) {
       // Redirect old pagination URLs
       const [,page] = window.location.pathname.match(/\/page\/(\d+)\/$/) || [];
       if (page) {

--- a/404.html
+++ b/404.html
@@ -3,9 +3,15 @@
 
 <head>
   <title>Page not found</title>
-  <script type="module">
+  <script type="text/javascript">
     window.isErrorPage = true;
     window.errorCode = '404';
+  </script>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta property="og:title" content="Page not found">
+  <script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+  <script type="module">
+    import { sampleRUM } from '/scripts/lib-franklin.js';
 
     // Trying to fix URLs producing 404s
 
@@ -26,12 +32,6 @@
         window.location.replace(article.path);
       }
     }
-  </script>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:title" content="Page not found">
-  <script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
-  <script type="module">
-    import { sampleRUM } from '/scripts/lib-franklin.js';
 
     window.addEventListener('load', () => {
       if (document.referrer) {

--- a/404.html
+++ b/404.html
@@ -3,7 +3,7 @@
 
 <head>
   <title>Page not found</title>
-  <script type="text/javascript">
+  <script type="module">
     window.isErrorPage = true;
     window.errorCode = '404';
 
@@ -19,14 +19,12 @@
     // Try to identify vanity URLs
     const tokens = pathname.split('/').filter((token) => !!token);
     if (tokens.length === 1) {
-      (async function() {
-        const resp = await fetch('/article/query-index.json?sheet=article&limit=-1');
-        const json = await resp.json();
-        const article = json.data.find((article) => article.path.endsWith(tokens[0]));
-          if (article) {
-            window.location.replace(article.path);
-          }
-      })();
+      const resp = await fetch('/article/query-index.json?sheet=article&limit=-1');
+      const json = await resp.json();
+      const article = json.data.find((article) => article.path.endsWith(tokens[0]));
+      if (article) {
+        window.location.replace(article.path);
+      }
     }
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/404.html
+++ b/404.html
@@ -36,7 +36,8 @@
     if (!redirecting && tokens.length) {
       const resp = await fetch('/article/query-index.json?sheet=article&limit=-1');
       const json = await resp.json();
-      const article = json.data.find((article) => article.path.endsWith(tokens.pop()));
+      const token = tokens.pop();
+      const article = json.data.find((article) => article.path.endsWith(token));
       if (article) {
         redirecting = true;
         window.location.replace(article.path);

--- a/404.html
+++ b/404.html
@@ -13,22 +13,25 @@
   <script type="module">
     import { sampleRUM } from '/scripts/lib-franklin.js';
 
+    let redirecting = false;
     // Trying to fix URLs producing 404s
 
     // Redirect old pagination URLs
     const { pathname } = window.location;
     const [,page] = pathname.match(/\/page\/(\d+)\/$/) || [];
     if (page) {
+      redirecting = true;
       window.location.replace(pathname.replace(/\/page\/(\d+)\/$/, `?page=${page}`));
     }
 
     // Try to identify vanity URLs
     const tokens = pathname.split('/').filter((token) => !!token);
-    if (tokens.length === 1) {
+    if (!redirecting && tokens.length === 1) {
       const resp = await fetch('/article/query-index.json?sheet=article&limit=-1');
       const json = await resp.json();
       const article = json.data.find((article) => article.path.endsWith(tokens[0]));
       if (article) {
+        redirecting = true;
         window.location.replace(article.path);
       }
     }
@@ -49,7 +52,9 @@
     });
 
     sampleRUM('404', { source: document.referrer, target: window.location.href });
-    window.location.replace('/');
+    if (!redirecting) {
+      window.location.replace('/');
+    }
   </script>
   <link rel="stylesheet" href="/styles/styles.css">
   <style>

--- a/404.html
+++ b/404.html
@@ -10,9 +10,10 @@
     // Trying to fix URLs producing 404s
 
     // Redirect old pagination URLs
-    const [,page] = window.location.pathname.match(/\/page\/(\d+)\/$/) || [];
+    const { pathname } = window.location;
+    const [,page] = pathname.match(/\/page\/(\d+)\/$/) || [];
     if (page) {
-      window.location.replace(window.location.pathname.replace(/\/page\/(\d+)\/$/, `?page=${page}`));
+      window.location.replace(pathname.replace(/\/page\/(\d+)\/$/, `?page=${page}`));
     }
 
     // Try to identify vanity URLs

--- a/404.html
+++ b/404.html
@@ -18,10 +18,10 @@
 
     // Redirect old pagination URLs
     const { pathname } = window.location;
-    let [,page] = pathname.match(/\/page\/(\d+)\/$/) || [];
+    let [,page] = pathname.match(/\/page\/(\d+)\/?$/) || [];
     if (page) {
       redirecting = true;
-      window.location.replace(pathname.replace(/\/page\/(\d+)\/$/, `?page=${page}`));
+      window.location.replace(pathname.replace(/\/page\/(\d+)\/?$/, `?page=${page}`));
     }
 
     // Redirect invalid pagination URLs

--- a/404.html
+++ b/404.html
@@ -33,10 +33,10 @@
 
     // Try to identify vanity URLs
     const tokens = pathname.split('/').filter((token) => !!token);
-    if (!redirecting && tokens.length === 1) {
+    if (!redirecting && tokens.length) {
       const resp = await fetch('/article/query-index.json?sheet=article&limit=-1');
       const json = await resp.json();
-      const article = json.data.find((article) => article.path.endsWith(tokens[0]));
+      const article = json.data.find((article) => article.path.endsWith(tokens.pop()));
       if (article) {
         redirecting = true;
         window.location.replace(article.path);


### PR DESCRIPTION
Wordpress used to have different paginated URLs, and also support short vanity URLs.
This PR tries to handles those redirects client-side as a fallback if the server-side doesn't have them configured.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://fix-404s--petplace--hlxsites.hlx.page/article/birds/general/choosing-a-ringneck-parakeet/2/ (invalid pagination)
  - https://fix-404s--petplace--hlxsites.hlx.page/chemical-burns-in-cats/ (short vanity)
  - https://fix-404s--petplace--hlxsites.hlx.page/article/dogs/selecting-a-dog/choosing-a-breed/choosing-a-keeshond (moved article)
