### PR TITLE
feat: only show newsletter popup once per visitor

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -704,10 +704,10 @@ async function loadNewsletterPopup(footer) {
   if (isNewsletterSignedUp()) {
     return;
   }
-  if (sessionStorage.getItem(NEWSLETTER_POPUP_KEY)) {
+  if (localStorage.getItem(NEWSLETTER_POPUP_KEY)) {
     return;
   }
-  sessionStorage.setItem(NEWSLETTER_POPUP_KEY, 'true');
+  localStorage.setItem(NEWSLETTER_POPUP_KEY, 'true');
   const popupContainer = document.createElement('div');
   const newsletterBlock = await createNewsletterAutoBlock('/fragments/newsletter-popup', (block) => {
     popupContainer.append(block);


### PR DESCRIPTION
Per feedback from petplace team, use local storage instead of session storage to remember if newsletter popup has been displayed.

Fix #257 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://issue-257-fix--petplace--hlxsites.hlx.page/
  - https://issue-257-fix--petplace--hlxsites.hlx.page/?martech=off
