### PR TITLE
feat: add semantic schemas

### DIFF
--- a/blocks/article-author/article-author.js
+++ b/blocks/article-author/article-author.js
@@ -15,10 +15,13 @@ export default async function decorate(block) {
   const defaultAvatarIcon = document.createElement('span');
   defaultAvatarIcon.classList.add('icon', 'icon-user');
   const avatarIfExist = avatar ? createOptimizedPicture(avatar, authorTitle) : defaultAvatarIcon;
+  avatarIfExist.querySelector('img')?.setAttribute('itemprop', 'image');
   block.innerHTML = `
-    <p>${titleWithLinkIfExist}</p>
-    <time datetime="${date}">${date}</time>`;
-  block.prepend(avatarIfExist);
+    <div itemprop="author" itemscope itemtype="https://schema.org/Person">
+      <p itemprop="name">${titleWithLinkIfExist}</p>
+    </div>
+    <time itemprop="datePublished" datetime="${date}">${date}</time>`;
+  block.firstElementChild.prepend(avatarIfExist);
   decorateIcons(block);
   setTimeout(() => {
     window.requestAnimationFrame(() => {

--- a/blocks/article-navigation/article-navigation.js
+++ b/blocks/article-navigation/article-navigation.js
@@ -32,17 +32,22 @@ function createArticleDetails(block, key, categoryInfo, article) {
   const categoryHref = categoryInfo ? categoryInfo.Path : '#';
   const category = document.createElement('div');
   category.classList.add('article-navigation-category');
-  category.innerHTML = `<a href="${categoryHref}">${categoryInfo.Category}</a>`;
+  category.innerHTML = `<a href="${categoryHref}"><span itemprop="about">${categoryInfo.Category}</span></a>`;
 
   // title of the article, which will link to the article's page
   const title = document.createElement('div');
   title.classList.add('article-navigation-title');
   title.innerHTML = `
-    <a href="${article.path}"><div class="article-navigation-${key}-title-text">${article.title}</div></a>
+    <a href="${article.path}">
+      <span class="article-navigation-${key}-title-text" itemprop="name">${article.title}</span>
+      <link itemprop="url" href="${article.path}"/>
+    </a>
   `;
 
   const sectionContainer = document.createElement('div');
   sectionContainer.classList.add('article-navigation-details', `article-navigation-${key}-details`);
+  sectionContainer.setAttribute('itemscope', '');
+  sectionContainer.setAttribute('itemtype', 'https://schema.org/Article');
   sectionContainer.append(category);
   sectionContainer.append(title);
 

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -20,23 +20,32 @@ async function buildPost(post, eager) {
 
   const postCard = document.createElement('div');
   postCard.classList.add('blog-cards');
+  postCard.setAttribute('itemscope', '');
+  postCard.setAttribute('itemtype', 'https://schema.org/Article');
   const postDate = new Date(0);
   postDate.setUTCSeconds(post.date);
   const style = `--bg-color: var(--color-${category.Color}); --border-color: var(--color-${category.Color}); `;
   postCard.innerHTML = `
-      <div class="blogs-card-image">
-        <a href="${post.path}">${createOptimizedPicture(post.image, `Teaser image for ${post.title}`, eager, [{ width: 800 }]).outerHTML}</a>
-        ${category.Category !== 'Breeds' ? `<a class="blogs-card-category" href=${category.Path} style ="${style}">${category.Category}</a>` : ''}
-      </div>
-      <div>              
-        <a href="${post.path}">
+    <div class="blogs-card-image">
+      <a href="${post.path}">${createOptimizedPicture(post.image, `Teaser image for ${post.title}`, eager, [{ width: 800 }]).outerHTML}</a>
+      ${category.Category !== 'Breeds' ? `<a class="blogs-card-category" href=${category.Path} style ="${style}"><span itemprop="about">${category.Category}</span></a>` : ''}
+    </div>
+    <div>
+      <a href="${post.path}">
         <div class="blogs-card-body">
-        <h3>${post.title.replace(/- PetPlace$/, '')}</h3>
-        ${category.Category !== 'Breeds' ? `<p><span class="card-date"> <time datetime="${postDate.toISOString().substring(0, 10)}">${dateFormatter.format(postDate)}</time> · ${post.author}</span></p>` : ''}
-      </div></a>          
-      </div>
-    </a>
-  `;
+          <link itemprop="url" href="${post.path}"/>
+          <h3 itemprop="name">${post.title.replace(/- PetPlace$/, '')}</h3>
+          ${category.Category !== 'Breeds' ? `<p>
+            <span class="card-date">
+              <time itemprop="datePublished" datetime="${postDate.toISOString().substring(0, 10)}">${dateFormatter.format(postDate)}</time> · 
+              <span itemprop="author">${post.author}</span>
+            </span>
+          </p>` : ''}
+        </div>
+      </a>
+    </div>
+  </a>`;
+  postCard.querySelector('img').setAttribute('itemprop', 'image');
   return postCard;
 }
 

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -52,6 +52,8 @@ async function buildPost(post, eager) {
 async function buildAuthorPost(post, eager) {
   const postCard = document.createElement('div');
   postCard.classList.add('blog-cards');
+  postCard.setAttribute('itemscope', '');
+  postCard.setAttribute('itemtype', 'https://schema.org/Person');
   postCard.innerHTML = `
       <div class="blogs-card-image">
         <a href="${post.path}">${createOptimizedPicture(post.avatar, `Avatar image for ${post.title}`, eager, [{ width: 800 }]).outerHTML}</a>
@@ -59,12 +61,13 @@ async function buildAuthorPost(post, eager) {
       <div>              
         <a href="${post.path}">
         <div class="blogs-card-body">
-        <h3>${post.title.replace(/- Petplace$/i, '')}</h3>
+        <h3 itemprop="name">${post.title.replace(/- Petplace$/i, '')}</h3>
         <span class="read-more">Read more</span>
       </div></a>          
       </div>
     </a>
   `;
+  postCard.querySelector('img').setAttribute('itemprop', 'image');
   return postCard;
 }
 

--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -9,7 +9,8 @@
 * OF ANY KIND, either express or implied. See the License for the specific language
 * governing permissions and limitations under the License.
 */
-.embed {
+.embed,
+.embed > div {
   display: flex;
   margin: 0 auto 2rem;
   padding: 0;
@@ -18,6 +19,7 @@
   max-width: 100%;
 }
 
+.embed > div,
 .embed blockquote,
 .embed iframe {
   flex: 1;

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -14,28 +14,51 @@ const embedYoutubeFacade = (url) => {
   } else {
     videoId = url.pathname.split('/').pop();
   }
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('itemscope', '');
+  wrapper.setAttribute('itemtype', 'https://schema.org/VideoObject');
+  const link = document.createElement('link');
+  link.setAttribute('itemprop', 'embedUrl');
+  link.href = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&playsinline=1`;
+  wrapper.append(link);
   const litePlayer = document.createElement('lite-youtube');
   litePlayer.setAttribute('videoid', videoId);
-  return litePlayer.outerHTML;
+  wrapper.append(litePlayer);
+  return wrapper.outerHTML;
 };
 
 const embedInstagram = (url) => {
   const endingSlash = url.pathname.endsWith('/') ? '' : '/';
   const location = window.location.href.endsWith('.html') ? window.location.href : `${window.location.href}.html`;
   const src = `${url.origin}${url.pathname}${endingSlash}embed/captioned/?rd=${window.encodeURIComponent(location)}`;
-  const embedHTML = `<iframe src="${src}" allowfullscreen allowtransparency scrolling="no" frameborder="0" loading="lazy"></iframe>`;
+  const embedHTML = `
+    <div itemscope itemtype="https://schema.org/SocialMediaPosting">
+      <link itemprop="url" href="${url.origin}${url.pathname}${endingSlash}embed/captioned/"/>
+      <iframe itemprop="url" src="${src}" allowfullscreen allowtransparency scrolling="no" frameborder="0" loading="lazy"></iframe>
+    </div>
+  `;
   return embedHTML;
 };
 
 const embedTwitter = (url) => {
   loadScript('https://platform.twitter.com/widgets.js');
-  const embedHTML = `<blockquote><a href="${url}"></a></blockquote>`;
+  const embedHTML = `
+    <blockquote itemscope itemtype="https://schema.org/SocialMediaPosting">
+      <a itemprop="url" href="${url}"></a>
+    </blockquote>
+  `;
   return embedHTML;
 };
 
 const embedTiktokFacade = async (url) => {
   loadScript('/blocks/embed/lite-tiktok/lite-tiktok.js', () => {}, { async: true, type: 'module' });
-  return `<lite-tiktok videoid="${url.pathname.split('/').pop()}"></lite-tiktok>`;
+  const videoId = url.pathname.split('/').pop();
+  return `
+    <div itemscope itemtype="https://schema.org/VideoObject">
+      <link itemprop="embedUrl" href="https://www.tiktok.com/video/${videoId}"/>
+      <lite-tiktok videoid="${videoId}"></lite-tiktok>
+    </div>
+  `;
 };
 
 const EMBEDS_CONFIG = {

--- a/blocks/pet-insurance-quote/pet-insurance-quote.js
+++ b/blocks/pet-insurance-quote/pet-insurance-quote.js
@@ -5,6 +5,7 @@ export default function decorate(block) {
   // pages that don't have content. Continue showing nothing for those cases
   if (!block.textContent.trim()) {
     block.remove();
+    return;
   }
 
   if (sampleRUM.convert) {

--- a/blocks/popular-articles/popular-articles.js
+++ b/blocks/popular-articles/popular-articles.js
@@ -91,18 +91,21 @@ export default async function decorate(block) {
 
     PopularPostsData.forEach((post, i) => {
       const popularPostsWrapper = `
-      <div class="popular-posts-card">
-        <a href=" ${post.path}">
+        <div class="popular-posts-card" itemscope itemtype="https://schema.org/Article">
+          <a href="${post.path}">
             <div class="img-div"></div>
-        </a>
-        <div class="title-div">
-            <a href="${post.categoryPath}">${post.category}</a>
-            <a href=" ${post.path}"><h3>${post.title}</h3></a>
-        </div>
-      </div>          
-    `;
+          </a>
+          <div class="title-div">
+            <a href="${post.categoryPath}"><span itemprop="about">${post.category}<span></a>
+            <a href="${post.path}"><h3 itemprop="name">${post.title}</h3></a>
+            <link itemprop="url" href="${post.path}"/>
+          </div>
+        </div>          
+      `;
       cardWrapper.innerHTML += popularPostsWrapper;
-      cardWrapper.querySelectorAll('.img-div')[i].append(createOptimizedPicture(post.image, post.imageAlt, false, [{ width: '300' }]));
+      const imgDiv = cardWrapper.querySelectorAll('.img-div')[i];
+      imgDiv.append(createOptimizedPicture(post.image, post.imageAlt, false, [{ width: '300' }]));
+      imgDiv.querySelector('img').setAttribute('itemprop', 'image');
     });
 
     return block.append(cardWrapper);

--- a/blocks/tiles/tiles.js
+++ b/blocks/tiles/tiles.js
@@ -73,6 +73,8 @@ export default async function decorate(block) {
     // Create tile div for each individual tile
     const tile = document.createElement('div');
     tile.classList.add('tile');
+    tile.setAttribute('itemscope', '');
+    tile.setAttribute('itemtype', 'https://schema.org/Article');
 
     const imgPadding = document.createElement('div');
     if (index === 0) {
@@ -115,6 +117,7 @@ export default async function decorate(block) {
       img = picture.querySelector('img');
       img.width = 200;
       img.height = 200;
+      img.setAttribute('itemprop', 'image');
     }
 
     // Create content div.  This contains title, author, date etc..
@@ -127,7 +130,7 @@ export default async function decorate(block) {
     const categoryLink = document.createElement('a');
     categoryLink.classList.add('category-link-btn');
     categoryLink.href = categories[index]?.Path;
-    categoryLink.innerHTML = categories[index]?.Category;
+    categoryLink.innerHTML = `<span itemprop="about">${categories[index]?.Category}</span>`;
     categoryLink.style.setProperty('--bg-color', `var(--color-${categories[index]?.Color})`);
 
     if (index !== 0) {
@@ -140,17 +143,30 @@ export default async function decorate(block) {
     const title = document.createElement('a');
     title.href = dta.path;
     const titleHeader = document.createElement('h3');
+    titleHeader.setAttribute('itemprop', 'name');
     titleHeader.innerHTML = tileTitle;
     title.append(titleHeader);
+    const link = document.createElement('link');
+    link.setAttribute('itemprop', 'url');
+    link.setAttribute('href', dta.path);
+    title.append(link);
     const dateAuthorContainer = document.createElement('div');
     dateAuthorContainer.classList.add('date-author-container');
 
     const date = new Date(dta.date * 1000);
     date.setHours(date.getHours() + (date.getTimezoneOffset() / 60));
-    const formattedDate = `${monthNames[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
+    const formattedDate = document.createElement('span');
+    formattedDate.setAttribute('itemprop', 'datePublished');
+    formattedDate.setAttribute('content', date.toISOString().substring(0, 10));
+    formattedDate.textContent = `${monthNames[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
 
-    dateAuthorContainer.append(`${formattedDate} · `);
-    dateAuthorContainer.append(dta.author);
+    const author = document.createElement('span');
+    author.setAttribute('itemprop', 'author');
+    author.textContent = dta.author;
+
+    dateAuthorContainer.append(formattedDate);
+    dateAuthorContainer.append(' · ');
+    dateAuthorContainer.append(author);
 
     imgContainer.append(imgPadding);
     imgContainer.append(picture);

--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -141,9 +141,16 @@ export async function loadEager(main) {
   adId.innerText = await getCategoryAd(categorySlug);
   const adBlock = buildBlock('ad', { elems: [adId] });
   ad.append(adBlock);
+
+  main.setAttribute('itemscope', '');
+  main.setAttribute('itemtype', 'https://schema.org/Article');
 }
 
 export async function loadLazy(main) {
+  main.querySelector('.hero h1').setAttribute('itemprop', 'name');
+  main.querySelector('.hero img').setAttribute('itemprop', 'image');
+  main.querySelector('.section:nth-of-type(2)').setAttribute('itemprop', 'articleBody');
+
   const breadCrumbs = main.querySelector('.hero > div > div');
   const categorySlugs = getMetadata('category').split(',').map((slug) => toClassName(slug.trim()));
   const crumbData = await getBreadcrumbs(categorySlugs[0]);


### PR DESCRIPTION
Adding various semantic schemas for better SEO:
- https://schema.org/Article with its author on article pages, including for popular posts and article navigation
- https://schema.org/Article on the home page and category index pages
- https://schema.org/Person for authors index
- https://schema.org/VideoObject and https://schema.org/SocialMediaPosting for the various embeds

Fix #312 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.live/
- After:
  - https://add-schemas--petplace--hlxsites.hlx.live/article/cats/pet-care/caracals-as-pets
  - https://add-schemas--petplace--hlxsites.hlx.live/
  - https://add-schemas--petplace--hlxsites.hlx.live/article/category/pet-care/
  - https://add-schemas--petplace--hlxsites.hlx.live/authors/
