### PR TITLE
feat: add support for annotating article pages as FAQ

### DIFF
--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -189,7 +189,7 @@ export async function loadLazy(main) {
   main.querySelector('.hero h1').setAttribute('itemprop', 'name');
   main.querySelector('.hero img').setAttribute('itemprop', 'image');
   const articleType = toClassName(getMetadata('type'));
-  if (!articleType) {
+  if (articleType !== 'faq') {
     main.querySelector('.section:nth-of-type(2)').setAttribute('itemprop', 'articleBody');
   }
 

--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -143,13 +143,55 @@ export async function loadEager(main) {
   ad.append(adBlock);
 
   main.setAttribute('itemscope', '');
-  main.setAttribute('itemtype', 'https://schema.org/Article');
+  const articleType = toClassName(getMetadata('type'));
+  if (articleType === 'faq') {
+    main.setAttribute('itemtype', 'https://schema.org/FAQPage');
+    [...main.querySelectorAll(':scope > div > :is(h1,h2)')]
+      .filter((h) => h.textContent.endsWith('?'))
+      .forEach((h) => {
+        if (h.nodeName === 'H1') {
+          const meta = document.createElement('meta');
+          meta.setAttribute('itemprop', 'name');
+          meta.setAttribute('content', h.textContent);
+          h.after(meta);
+        } else {
+          h.setAttribute('itemprop', 'name');
+        }
+        const question = document.createElement('div');
+        question.setAttribute('itemscope', '');
+        question.setAttribute('itemprop', 'mainEntity');
+        question.setAttribute('itemtype', 'https://schema.org/Question');
+        if (h.nodeName === 'H1') {
+          h.after(question);
+          question.append(question.nextElementSibling);
+        } else {
+          h.replaceWith(question);
+          question.append(h);
+        }
+        const answer = document.createElement('div');
+        answer.setAttribute('itemscope', '');
+        answer.setAttribute('itemprop', 'acceptedAnswer');
+        answer.setAttribute('itemtype', 'https://schema.org/Answer');
+        question.append(answer);
+        const div = document.createElement('div');
+        div.setAttribute('itemprop', 'text');
+        answer.append(div);
+        while (question.nextElementSibling && question.nextElementSibling.tagName !== 'H2') {
+          div.append(question.nextElementSibling);
+        }
+      });
+  } else {
+    main.setAttribute('itemtype', 'https://schema.org/Article');
+  }
 }
 
 export async function loadLazy(main) {
   main.querySelector('.hero h1').setAttribute('itemprop', 'name');
   main.querySelector('.hero img').setAttribute('itemprop', 'image');
-  main.querySelector('.section:nth-of-type(2)').setAttribute('itemprop', 'articleBody');
+  const articleType = toClassName(getMetadata('type'));
+  if (!articleType) {
+    main.querySelector('.section:nth-of-type(2)').setAttribute('itemprop', 'articleBody');
+  }
 
   const breadCrumbs = main.querySelector('.hero > div > div');
   const categorySlugs = getMetadata('category').split(',').map((slug) => toClassName(slug.trim()));


### PR DESCRIPTION
Adds support for specifying the `Type: FAQ` metadata on an article so it gets automatically decorated with the https://schema.org/FAQPage so it gets better indexing by Google (see: https://developers.google.com/search/docs/appearance/structured-data/faqpage).

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://faq-pages--petplace--hlxsites.hlx.live/article/dogs/pet-care/dog-faq-part-1
  - https://faq-pages--petplace--hlxsites.hlx.live/article/dogs/pet-care/dog-faq-part-2
  - https://faq-pages--petplace--hlxsites.hlx.live/article/dogs/just-for-fun/can-the-avian-flu-bird-flu-infect-dogs
