### PR TITLE
feat: capture newsletter errors as rum data.

### DIFF
--- a/blocks/newsletter-signup/newsletter-signup.js
+++ b/blocks/newsletter-signup/newsletter-signup.js
@@ -1,5 +1,5 @@
 import { createForm } from '../form/form.js';
-import { setNewsletterSignedUp } from '../../scripts/scripts.js';
+import { setNewsletterSignedUp, captureError } from '../../scripts/scripts.js';
 
 function showMessage(block, message, clazz = 'success') {
   const messageElement = block.querySelector('.newsletter-message');
@@ -37,12 +37,14 @@ async function submitForm(block, fd) {
   try {
     const res = await fetch('https://api.iterable.com/api/users/update', fetchOpts);
     if (!res.ok) {
+      captureError(new Error(`iterable API responded with ${res.status} status code`));
       showError(block, fd);
     } else {
       setNewsletterSignedUp();
       showMessage(block, fd.Success);
     }
   } catch (e) {
+    captureError(e);
     showError(block, fd);
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -981,6 +981,14 @@ export async function createBreadCrumbs(crumbData, chevronAll = false) {
   return breadcrumbContainer;
 }
 
+/**
+ * Logs the information about an error encountered by the site.
+ * @param {Error} e Error information to log.
+ */
+export async function captureError(e) {
+  sampleRUM('error', e);
+}
+
 async function loadPage() {
   await loadEager(document);
   await loadLazy(document);


### PR DESCRIPTION
As requested by petplace team, capture details about errors that occur when attempting to submit newsletter data to iterable.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://rum-error--petplace--hlxsites.hlx.page/
  - https://rum-error--petplace--hlxsites.hlx.page/?martech=off
