### PR TITLE
feat: add form to newsletter signup page

### DIFF
--- a/blocks/blade/blade.js
+++ b/blocks/blade/blade.js
@@ -1,4 +1,4 @@
-import { createOptimizedPicture, loadBlock, decorateBlock } from '../../scripts/lib-franklin.js';
+import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
 
 const IMAGE_WIDTH = 450;
 export default function decorate(block) {
@@ -17,39 +17,4 @@ export default function decorate(block) {
       }
     });
   });
-  [...block.querySelectorAll('a[href]')]
-    .filter((a) => {
-      try {
-        return new URL(a.href).pathname === new URL(a.textContent).pathname
-      } catch (e) {
-        return false;
-      }
-    })
-    .forEach(async (a) => {
-      const parent = a.parentElement;
-      a.remove();
-      const url = `${window.location.protocol}//${window.location.host}${new URL(a.href).pathname}`;
-      const res = await fetch(url);
-      if (!res.ok) {
-        return;
-      }
-      const text = await res.text();
-      const div = document.createElement('div');
-      div.innerHTML = text;
-      const main = div.querySelector('main');
-      if (!main || !main.children.length) {
-        return;
-      }
-      const blockParent = main.children.item(0);
-      if (!blockParent.children.length) {
-        return;
-      }
-      const block = blockParent.children.item(0);
-      if (!block.classList.length || !block.children.length || !block.children.item(0).children.length) {
-        return;
-      }
-      parent.append(block);
-      decorateBlock(block);
-      loadBlock(block);
-    });
 }

--- a/blocks/blade/blade.js
+++ b/blocks/blade/blade.js
@@ -1,4 +1,4 @@
-import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
+import { createOptimizedPicture, loadBlock, decorateBlock } from '../../scripts/lib-franklin.js';
 
 const IMAGE_WIDTH = 450;
 export default function decorate(block) {
@@ -17,4 +17,39 @@ export default function decorate(block) {
       }
     });
   });
+  [...block.querySelectorAll('a[href]')]
+    .filter((a) => {
+      try {
+        return new URL(a.href).pathname === new URL(a.textContent).pathname
+      } catch (e) {
+        return false;
+      }
+    })
+    .forEach(async (a) => {
+      const parent = a.parentElement;
+      a.remove();
+      const url = `${window.location.protocol}//${window.location.host}${new URL(a.href).pathname}`;
+      const res = await fetch(url);
+      if (!res.ok) {
+        return;
+      }
+      const text = await res.text();
+      const div = document.createElement('div');
+      div.innerHTML = text;
+      const main = div.querySelector('main');
+      if (!main || !main.children.length) {
+        return;
+      }
+      const blockParent = main.children.item(0);
+      if (!blockParent.children.length) {
+        return;
+      }
+      const block = blockParent.children.item(0);
+      if (!block.classList.length || !block.children.length || !block.children.item(0).children.length) {
+        return;
+      }
+      parent.append(block);
+      decorateBlock(block);
+      loadBlock(block);
+    });
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -290,7 +290,7 @@ export function decorateResponsiveImages(container, breakpoints = [440, 768]) {
  * @param {Element} main The container element
  */
 async function buildHeroBlock(main) {
-  const excludedPages = ['home-page', 'breed-index', 'searchresults'];
+  const excludedPages = ['home-page', 'breed-index', 'searchresults', 'article-signup'];
   const bodyClass = [...document.body.classList];
   // check the page's body class to see if it matched the list
   // of excluded page for auto-blocking the hero
@@ -679,7 +679,7 @@ async function optimizedBatchLoading(promises) {
   return Promise.all(promises.map((promise) => promise()));
 }
 
-async function createNewsletterAutoBlock(fragmentUrl, addElement) {
+export async function createNewsletterAutoBlock(fragmentUrl, addElement) {
   const res = await fetch(fragmentUrl);
   const text = await res.text();
 

--- a/templates/article-signup/article-signup.css
+++ b/templates/article-signup/article-signup.css
@@ -1,0 +1,12 @@
+.article-signup main h1 {
+  color: var(--text-color);
+}
+
+.article-signup main .section {
+  display: flex;
+  gap: 1rem;
+}
+
+.article-signup main .newsletter-signup {
+  margin-top: 1rem;
+}

--- a/templates/article-signup/article-signup.js
+++ b/templates/article-signup/article-signup.js
@@ -1,0 +1,20 @@
+import { createNewsletterAutoBlock } from '../../scripts/scripts.js';
+import { loadBlock } from '../../scripts/lib-franklin.js';
+
+// eslint-disable-next-line import/prefer-default-export
+export async function loadLazy(main) {
+  const picture = main.querySelector('picture');
+  const defaultContent = main.querySelector('.default-content-wrapper');
+  if (picture && defaultContent) {
+    const pictureParent = picture.parentElement;
+    defaultContent.parentElement.insertBefore(picture, defaultContent);
+    if (pictureParent.children.length === 0) {
+      pictureParent.remove();
+    }
+    const newsletter = await createNewsletterAutoBlock('/fragments/newsletter-footer', (block) => {
+      defaultContent.append(block);
+    });
+    newsletter.classList.add('horizontal');
+    await loadBlock(newsletter);
+  }
+}


### PR DESCRIPTION
I tried a few different options for this page, and the one that I settled on was creating a new template for the page. I went this route because it ended up being very simple. 

For example, trying to use the default template and a blade block ended up being complex because it involved a content fragment (due to the block-within-a-block), and I ran it got pretty convoluted trying to extend the blade block so that we could embed a content fragment within it.

As it is, going the template route allowed me to simply append the signup form to the page's main section. The form reuses the popup's content fragment, so the form on this page is the same one that appears in the site's popup.

Fix #319 

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/drafts/frisbey/newsletter-signup
- After:
  - https://issue-319--petplace--hlxsites.hlx.page/drafts/frisbey/newsletter-signup
  - https://issue-319--petplace--hlxsites.hlx.page/drafts/frisbey/newsletter-signup?martech=off
