### PR TITLE
feat: capture additional detail from iterable errors.

### DIFF
--- a/blocks/newsletter-signup/newsletter-signup.js
+++ b/blocks/newsletter-signup/newsletter-signup.js
@@ -37,7 +37,13 @@ async function submitForm(block, fd) {
   try {
     const res = await fetch('https://api.iterable.com/api/users/update', fetchOpts);
     if (!res.ok) {
-      captureError('newsletter-signup', new Error(`iterable API responded with ${res.status} status code`));
+      let text = 'no detail.';
+      try {
+        text = await res.text();
+      } catch {
+        // swallowing exception if there are issues reading response
+      }
+      captureError('newsletter-signup', new Error(`iterable API responded with ${res.status} status code: ${text}`));
       showError(block, fd);
     } else {
       setNewsletterSignedUp();


### PR DESCRIPTION
We've been seeing 400 responses from iterable, but there is no detail. Logging the response body as well as the status code whenever there are failures.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://error-detail--petplace--hlxsites.hlx.page/
  - https://error-detail--petplace--hlxsites.hlx.page/?martech=off
