### PR TITLE
feat: add GTM tag for ads tracking

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -19,7 +19,7 @@ import {
   createOptimizedPicture,
 } from './lib-franklin.js';
 // eslint-disable-next-line import/no-cycle
-import integrateMartech from './third-party.js';
+import { lazyMartech, delayedMartech } from './third-party.js';
 
 const NEWSLETTER_POPUP_KEY = 'petplace-newsletter-popup';
 const NEWSLETTER_SIGNUP_KEY = 'petplace-newsletter-signedup';
@@ -849,7 +849,7 @@ async function loadLazy(doc) {
   });
 
   if (!isMartechDisabled) {
-    integrateMartech();
+    lazyMartech();
     initPartytown();
   }
 
@@ -866,6 +866,7 @@ function loadDelayed(doc) {
     if (templateModule?.loadDelayed) {
       templateModule.loadDelayed(doc);
     }
+    delayedMartech();
     // eslint-disable-next-line import/no-cycle
     return import('./delayed.js');
   }, 3000);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -658,7 +658,7 @@ export function addFavIcon(href) {
 function initPartytown() {
   window.partytown = {
     lib: '/scripts/partytown/',
-    forward: ['dataLayer.push'],
+    forward: ['dataLayerProxy.push'],
   };
   import('./partytown/partytown.js');
 }
@@ -1004,8 +1004,8 @@ async function loadPage() {
 }
 
 // Initialize the data layer and mark the Google Tag Manager start event
-window.dataLayer ||= [];
-window.dataLayer.push({
+window.dataLayerProxy ||= [];
+window.dataLayerProxy.push({
   'gtm.start': Date.now(),
   event: 'gtm.js',
 });

--- a/scripts/third-party.js
+++ b/scripts/third-party.js
@@ -8,7 +8,7 @@ const GTM_SCRIPT = `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','${GTM_ID}');`;
+})(window,document,'script','dataLayerProxy','${GTM_ID}');`;
 
 function loadGTag(id) {
   loadScript(`https://www.googletagmanager.com/gtag/js?id=${TAG_ID}`, () => {
@@ -33,6 +33,7 @@ export default function integrateMartech() {
     loadScript('https://securepubads.g.doubleclick.net/tag/js/gpt.js', () => {}, { async: '' });
   }
 
+  window.dataLayer ||= [];
   loadScriptInWorker(GTM_SCRIPT, document.body);
   loadGTag(TAG_ID);
 }

--- a/scripts/third-party.js
+++ b/scripts/third-party.js
@@ -26,7 +26,7 @@ function loadScriptInWorker(innerHTML, parent) {
   parent.appendChild(script);
 }
 
-export default function integrateMartech() {
+export function lazyMartech() {
   // Load ads early on desktop since the impact is minimal there and
   // this helps reduce CLS and loading animation duration
   if (!isMobile() && document.querySelector('.block.ad')) {
@@ -35,5 +35,8 @@ export default function integrateMartech() {
 
   window.dataLayer ||= [];
   loadScriptInWorker(GTM_SCRIPT, document.body);
+}
+
+export function delayedMartech() {
   loadGTag(TAG_ID);
 }

--- a/scripts/third-party.js
+++ b/scripts/third-party.js
@@ -2,6 +2,7 @@
 import { isMobile, loadScript } from './scripts.js';
 
 const GTM_ID = 'GTM-WP2SGNL';
+const TAG_ID = 'AW-11334653569';
 
 const GTM_SCRIPT = `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -9,7 +10,16 @@ const GTM_SCRIPT = `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','${GTM_ID}');`;
 
-function createInlineScript(innerHTML, parent) {
+function loadGTag(id) {
+  loadScript(`https://www.googletagmanager.com/gtag/js?id=${TAG_ID}`, () => {
+    function gtag(...args) {
+      window.dataLayer.push(...args);
+    }
+    gtag('js', new Date());
+    gtag('config', id);
+  }, { async: '' });
+}
+function loadScriptInWorker(innerHTML, parent) {
   const script = document.createElement('script');
   script.type = 'text/partytown';
   script.innerHTML = innerHTML;
@@ -23,5 +33,6 @@ export default function integrateMartech() {
     loadScript('https://securepubads.g.doubleclick.net/tag/js/gpt.js', () => {}, { async: '' });
   }
 
-  createInlineScript(GTM_SCRIPT, document.body);
+  loadScriptInWorker(GTM_SCRIPT, document.body);
+  loadGTag(TAG_ID);
 }


### PR DESCRIPTION
Following https://adobe-dx-support.slack.com/archives/C04P5DFPDK9/p1695225389498879, we are moving the tag instrumentation from the webworker (partytown) directly in the main thread to avoid the CORS issues we are seeing.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.live/
- After:
  - https://gtm-tag-ads--petplace--hlxsites.hlx.live/
