### PR TITLE
fix: ads rendering on mobile

### DIFF
--- a/blocks/ad/ad.js
+++ b/blocks/ad/ad.js
@@ -63,7 +63,6 @@ function getAdSizes(el, ad) {
   const widths = parseAdSizes(ad.Width);
   const heights = parseAdSizes(ad.Height);
   const sizes = [];
-  let maxWidth;
   widths.forEach((width, i) => {
     if (heights.length > i && width <= el.clientWidth) {
       sizes.push([width, heights[i]]);

--- a/blocks/ad/ad.js
+++ b/blocks/ad/ad.js
@@ -135,9 +135,13 @@ export default async function decorate(block) {
     console.error('Unknown ad type', block.dataset.adid);
     return;
   }
+
+  block.classList.add('skeleton');
+
+  // Defer ad configuration until the block is rendered and we have a valid
+  // width to check against
   window.setTimeout(() => {
     const sizes = getAdSizes(block, data);
-    block.classList.add('skeleton');
     block.style.width = `${sizes[0][0]}px`;
     block.style.minHeight = `${sizes[0][1]}px`;
     window.googletag.cmd.push(() => {

--- a/blocks/ad/ad.js
+++ b/blocks/ad/ad.js
@@ -56,15 +56,16 @@ function parseAdSizes(rawSizes) {
   return null;
 }
 
-function getAdSizes(ad) {
+function getAdSizes(el, ad) {
   if (!ad) {
     return [];
   }
   const widths = parseAdSizes(ad.Width);
   const heights = parseAdSizes(ad.Height);
   const sizes = [];
+  let maxWidth;
   widths.forEach((width, i) => {
-    if (heights.length > i) {
+    if (heights.length > i && width <= el.clientWidth) {
       sizes.push([width, heights[i]]);
     }
   });
@@ -134,29 +135,31 @@ export default async function decorate(block) {
     console.error('Unknown ad type', block.dataset.adid);
     return;
   }
-  const sizes = getAdSizes(data);
-  block.classList.add('skeleton');
-  block.style.width = `${sizes[0][0]}px`;
-  block.style.minHeight = `${sizes[0][1]}px`;
-  window.googletag.cmd.push(() => {
-    const adSlot = window.googletag
-      .defineSlot(data.Path, sizes, id)
-      .addService(window.googletag.pubads());
+  window.setTimeout(() => {
+    const sizes = getAdSizes(block, data);
+    block.classList.add('skeleton');
+    block.style.width = `${sizes[0][0]}px`;
+    block.style.minHeight = `${sizes[0][1]}px`;
+    window.googletag.cmd.push(() => {
+      const adSlot = window.googletag
+        .defineSlot(data.Path, sizes, id)
+        .addService(window.googletag.pubads());
 
-    const targets = getAdTargets(data);
-    if (targets) {
-      adSlot.setTargeting(...targets);
-    }
-  });
-  // Enable SRA and services.
-  window.googletag.cmd.push(() => {
-    window.googletag.pubads().enableSingleRequest();
-    window.googletag.pubads().enableLazyLoad();
-    window.googletag.enableServices();
-  });
+      const targets = getAdTargets(data);
+      if (targets) {
+        adSlot.setTargeting(...targets);
+      }
+    });
+    // Enable SRA and services.
+    window.googletag.cmd.push(() => {
+      window.googletag.pubads().enableSingleRequest();
+      window.googletag.pubads().enableLazyLoad();
+      window.googletag.enableServices();
+    });
 
-  window.googletag.cmd.push(() => {
-    window.googletag.display(block.id);
+    window.googletag.cmd.push(() => {
+      window.googletag.display(block.id);
+    });
   });
 
   loadedObserver.observe(block, { attributes: true });


### PR DESCRIPTION
On mobile, sometimes the ads flow outside of the viewport and are not properly constrained to the visible area of the page.
We fix this by:
1. checking against the available `width` of the parent
2. deferring the size check to after the block renders (otherwise `width` would just be `0`)

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://fix-ads-mobile--petplace--hlxsites.hlx.page/
  - https://fix-ads-mobile--petplace--hlxsites.hlx.page/?martech=off

## Screenshots

### Before
<img width="409" alt="Screenshot 2023-10-04 at 8 54 34 AM" src="https://github.com/hlxsites/petplace/assets/1235810/e6b4b465-0136-40e0-b336-f896ff465231">

### After
<img width="410" alt="Screenshot 2023-10-04 at 8 54 14 AM" src="https://github.com/hlxsites/petplace/assets/1235810/dcd8a55d-89bc-4245-89f9-6b23db8340ba">


