### PR TITLE
fix: send data when submitting newsletter from popup

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -2,7 +2,7 @@ import { sampleRUM } from '../../scripts/lib-franklin.js';
 
 function createSelect(fd) {
   const select = document.createElement('select');
-  select.id = fd.Field;
+  select.name = fd.Field;
   if (fd.Placeholder) {
     const ph = document.createElement('option');
     ph.textContent = fd.Placeholder;
@@ -86,7 +86,7 @@ function createHeading(fd) {
 function createInput(fd) {
   const input = document.createElement('input');
   input.type = fd.Type;
-  input.id = fd.Field;
+  input.name = fd.Field;
   input.setAttribute('placeholder', fd.Placeholder);
   if (fd.Required && fd.Required !== 'false') {
     input.setAttribute('required', 'required');
@@ -105,7 +105,7 @@ function createInput(fd) {
 
 function createTextArea(fd) {
   const input = document.createElement('textarea');
-  input.id = fd.Field;
+  input.name = fd.Field;
   input.setAttribute('placeholder', fd.Placeholder);
   if (fd.Required && fd.Required !== 'false') {
     input.setAttribute('required', 'required');

--- a/blocks/newsletter-signup/newsletter-signup.js
+++ b/blocks/newsletter-signup/newsletter-signup.js
@@ -14,14 +14,12 @@ function showError(block, fd) {
 }
 
 async function submitForm(block, fd) {
-  const dognewsletter = block.querySelector('form input[name="dogs"]').checked;
-  const catnewsletter = block.querySelector('form input[name="cats"]').checked;
-  const email = String(block.querySelector('form input[name="email"]').value).trim();
+  const formData = new FormData(block.querySelector('form'));
   const payload = {
-    email,
+    email: formData.get('email'),
     dataFields: {
-      catnewsletter,
-      dognewsletter,
+      catnewsletter: formData.get('cats') === 'on',
+      dognewsletter: formData.get('dogs') === 'on',
     },
     mergeNestedObjects: true,
     createNewFields: true,

--- a/blocks/newsletter-signup/newsletter-signup.js
+++ b/blocks/newsletter-signup/newsletter-signup.js
@@ -14,9 +14,9 @@ function showError(block, fd) {
 }
 
 async function submitForm(block, fd) {
-  const dognewsletter = document.getElementById('dogs').checked;
-  const catnewsletter = document.getElementById('cats').checked;
-  const email = String(document.getElementById('email').value).trim();
+  const dognewsletter = block.querySelector('form input[name="dogs"]').checked;
+  const catnewsletter = block.querySelector('form input[name="cats"]').checked;
+  const email = String(block.querySelector('form input[name="email"]').value).trim();
   const payload = {
     email,
     dataFields: {


### PR DESCRIPTION
Create forms using `name` attribute instead of `id`. Ensure that newsletter form values are pulled from the block instead of the document.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://newsletter-popup-fix--petplace--hlxsites.hlx.page/
  - https://newsletter-popup-fix--petplace--hlxsites.hlx.page/?martech=off
