### PR TITLE
fix: simplify semantic schemas for better SEO

### DIFF
--- a/blocks/article-navigation/article-navigation.js
+++ b/blocks/article-navigation/article-navigation.js
@@ -32,22 +32,19 @@ function createArticleDetails(block, key, categoryInfo, article) {
   const categoryHref = categoryInfo ? categoryInfo.Path : '#';
   const category = document.createElement('div');
   category.classList.add('article-navigation-category');
-  category.innerHTML = `<a href="${categoryHref}"><span itemprop="about">${categoryInfo.Category}</span></a>`;
+  category.innerHTML = `<a href="${categoryHref}">${categoryInfo.Category}</a>`;
 
   // title of the article, which will link to the article's page
   const title = document.createElement('div');
   title.classList.add('article-navigation-title');
   title.innerHTML = `
     <a href="${article.path}">
-      <span class="article-navigation-${key}-title-text" itemprop="name">${article.title}</span>
-      <link itemprop="url" href="${article.path}"/>
+      <span class="article-navigation-${key}-title-text">${article.title}</span>
     </a>
   `;
 
   const sectionContainer = document.createElement('div');
   sectionContainer.classList.add('article-navigation-details', `article-navigation-${key}-details`);
-  sectionContainer.setAttribute('itemscope', '');
-  sectionContainer.setAttribute('itemtype', 'https://schema.org/Article');
   sectionContainer.append(category);
   sectionContainer.append(title);
 

--- a/blocks/popular-articles/popular-articles.js
+++ b/blocks/popular-articles/popular-articles.js
@@ -88,26 +88,22 @@ export default async function decorate(block) {
   if (!isAuthorPopularPosts) {
     const cardWrapper = document.createElement('div');
     cardWrapper.classList.add('popular-cards-wrapper');
-    cardWrapper.setAttribute('itemscope', true);
-    cardWrapper.setAttribute('itemtype', 'http://schema.org/ItemList');
 
     PopularPostsData.forEach((post, i) => {
       const popularPostsWrapper = `
-        <div class="popular-posts-card" itemprop="itemListElement" itemscope itemtype="https://schema.org/Article">
+        <div class="popular-posts-card">
           <a href="${post.path}">
             <div class="img-div"></div>
           </a>
           <div class="title-div">
-            <a href="${post.categoryPath}"><span itemprop="about">${post.category}<span></a>
-            <a href="${post.path}"><h3 itemprop="name">${post.title}</h3></a>
-            <link itemprop="url" href="${post.path}"/>
+            <a href="${post.categoryPath}">${post.category}</a>
+            <a href="${post.path}"><h3>${post.title}</h3></a>
           </div>
         </div>          
       `;
       cardWrapper.innerHTML += popularPostsWrapper;
       const imgDiv = cardWrapper.querySelectorAll('.img-div')[i];
       imgDiv.append(createOptimizedPicture(post.image, post.imageAlt, false, [{ width: '300' }]));
-      imgDiv.querySelector('img').setAttribute('itemprop', 'image');
     });
 
     return block.append(cardWrapper);

--- a/blocks/tiles/tiles.js
+++ b/blocks/tiles/tiles.js
@@ -14,8 +14,6 @@ export default async function decorate(block) {
   // Create containing div of three tiles (one big, two small)
   const tileContainer = document.createElement('div');
   tileContainer.className = 'tiles-block-container';
-  tileContainer.setAttribute('itemscope', true);
-  tileContainer.setAttribute('itemtype', 'http://schema.org/ItemList');
 
   if (!articles) {
     const data = await Promise.all([
@@ -75,7 +73,6 @@ export default async function decorate(block) {
     // Create tile div for each individual tile
     const tile = document.createElement('div');
     tile.classList.add('tile');
-    tile.setAttribute('itemprop', 'itemListElement');
     tile.setAttribute('itemscope', '');
     tile.setAttribute('itemtype', 'https://schema.org/Article');
 


### PR DESCRIPTION
Removes the ItemList and Article schemas on some of the blocks since those are making it harder for Google to properly index the content.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://simplify-schemas--petplace--hlxsites.hlx.page/
  - https://simplify-schemas--petplace--hlxsites.hlx.page/?martech=off
