### PR TITLE
fix: use the same datalayer for main and worker threads

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -964,8 +964,8 @@ async function loadPage() {
 }
 
 // Initialize the data layer and mark the Google Tag Manager start event
-window.dataLayerProxy ||= [];
-window.dataLayerProxy.push({
+window.dataLayer ||= [];
+window.dataLayer.push({
   'gtm.start': Date.now(),
   event: 'gtm.js',
 });

--- a/scripts/third-party.js
+++ b/scripts/third-party.js
@@ -8,7 +8,7 @@ const TAG_ID = 'AW-11334653569';
 function initPartytown() {
   window.partytown = {
     lib: '/scripts/partytown/',
-    forward: ['dataLayerProxy.push'],
+    forward: ['dataLayer.push'],
   };
   import('./partytown/partytown.js');
 }
@@ -17,7 +17,7 @@ const GTM_SCRIPT = `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayerProxy','${GTM_ID}');`;
+})(window,document,'script','dataLayer','${GTM_ID}');`;
 
 function loadGTag(id) {
   loadScript(`https://www.googletagmanager.com/gtag/js?id=${TAG_ID}`, () => {


### PR DESCRIPTION
As per discussion in https://adobe-dx-support.slack.com/archives/C04P5DFPDK9/p1699390137889779, we are trying to combine the datalayers to see if this fixes collection issues in analytics.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://datalayer-fix--petplace--hlxsites.hlx.page/
  - https://datalayer-fix--petplace--hlxsites.hlx.page/?martech=off
