### PR TITLE
feat: properly localize the 404 page including meta tags

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -442,7 +442,7 @@ export function getPlaceholder(key, options = {}) {
   }
   const placeholders = window.placeholders[window.hlx.contentBasePath || 'default'];
   if (!placeholders[key]) {
-    throw new Error(`Placeholder ${key} not found`);
+    throw new Error(`Placeholder "${key}" not found`);
   }
   return Object.entries(options).reduce((str, [k, v]) => str.replace(`{{${k}}}`, v), placeholders[key]);
 }

--- a/templates/searchresults/searchresults.js
+++ b/templates/searchresults/searchresults.js
@@ -23,7 +23,9 @@ function removeSkeletons(block) {
 }
 
 function noResultsHidePagination() {
-  document.querySelector('.pagination').style.display = 'none';
+  if (isTrueSearch) {
+    document.querySelector('.pagination').style.display = 'none';
+  }
   const searchResultText = document.querySelector('h2');
   searchResultText.innerHTML = getPlaceholder('noResults');
 }
@@ -197,6 +199,16 @@ export async function loadEager(document) {
   } else {
     const response = await fetch(`${window.hlx.contentBasePath}/fragments/404.plain.html`);
     main.innerHTML = await response.text();
+
+    // Update 404 page metadata
+    document.head.querySelector('title').textContent = `${getPlaceholder('pageNotFound')} | ${getPlaceholder('websiteName')}`;
+    document.head.querySelector('meta[property="og:title"]').content = document.head.title;
+    if (document.body.querySelector('.error-message')) {
+      document.body.querySelector('.error-message').textContent = document.head.title;
+    }
+    if (document.body.querySelector('.error-button-home')) {
+      document.body.querySelector('.error-button-home').textContent = getPlaceholder('goHome');
+    }
   }
 }
 


### PR DESCRIPTION
The content for the 404 page is already properly localized through #371, but the meta tags still need to be adjusted:

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/invalid
- After:
  - https://localized-404--petplace--hlxsites.hlx.live/invalid
  - https://localized-404--petplace--hlxsites.hlx.live/invalid?martech=off
  - https://localized-404--petplace--hlxsites.hlx.page/en-gb/invalid
  - https://localized-404--petplace--hlxsites.hlx.page/en-gb/invalid?martech=off
