### PR TITLE
feat: properly localize the sitemaps

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -7,9 +7,9 @@ indices:
       - 'article/category/default'
       - 'drafts/**'
       - 'fragments/**'
-      - 'tools/**'
       - 'en-gb/**'
-    properties:
+      - 'tools/**'
+    properties: &sitemap-base-props
       title:
         select: head > meta[property="og:title"]
         value: |
@@ -34,24 +34,10 @@ indices:
       - 'drafts/**'
       - 'tools/**'
       - 'en-gb/article/category/default'
+      - 'en-gb/drafts/**'
       - 'en-gb/fragments/**'
     properties:
-      title:
-        select: head > meta[property="og:title"]
-        value: |
-          attribute(el, 'content')
-      image:
-        select: head > meta[property="og:image"]
-        value: |
-          attribute(el, 'content')
-      description:
-        select: head > meta[name="description"]
-        value: |
-          attribute(el, 'content')
-      lastModified:
-        select: none
-        value: |
-          parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+      <<: *sitemap-base-props
       primary-language-url:
         select: head > meta[name="primary-language-url"]
         value: attribute(el, "content")

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -1,13 +1,14 @@
 version: 1
 
 indices:
-  sitemap:
+  sitemap-en-us:
     target: /query-index.xlsx
     exclude:
       - 'article/category/default'
       - 'drafts/**'
       - 'fragments/**'
       - 'tools/**'
+      - 'en-gb/**'
     properties:
       title:
         select: head > meta[property="og:title"]
@@ -25,6 +26,35 @@ indices:
         select: none
         value: |
           parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+  sitemap-en-gb:
+    target: /en-gb/query-index.xlsx
+    include:
+      - '/en-gb/**'
+    exclude:
+      - 'drafts/**'
+      - 'tools/**'
+      - '/en-gb/article/category/default'
+      - '/en-gb/fragments/**'
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      image:
+        select: head > meta[property="og:image"]
+        value: |
+          attribute(el, 'content')
+      description:
+        select: head > meta[name="description"]
+        value: |
+          attribute(el, 'content')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+      primary-language-url:
+        select: head > meta[name="primary-language-url"]
+        value: attribute(el, "content")
   articles:
     include:
       - '/article/**'

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -33,8 +33,8 @@ indices:
     exclude:
       - 'drafts/**'
       - 'tools/**'
-      - '/en-gb/article/category/default'
-      - '/en-gb/fragments/**'
+      - 'en-gb/article/category/default'
+      - 'en-gb/fragments/**'
     properties:
       title:
         select: head > meta[property="og:title"]

--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -1,6 +1,14 @@
 sitemaps:
-  default:
-    origin: https://www.petplace.com
-    source: /query-index.json
-    destination: /sitemap.xml
-    lastmod: YYYY-MM-DD
+  petplace:
+    default: en-us
+    languages:
+      en-us:
+        source: /query-index.json
+        destination: /sitemap.xml
+        hreflang: en-US
+        lastmod: YYYY-MM-DD
+      en-gb:
+        source: /en-gb/query-index.json
+        destination: /sitemap-en-gb.xml
+        hreflang: en-GB
+        lastmod: YYYY-MM-DD

--- a/sitemap-index.xml
+++ b/sitemap-index.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://www.petplace.com/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.example.com/sitemap-en-gb.xml</loc>
+  </sitemap>
+</sitemapindex>

--- a/sitemap-index.xml
+++ b/sitemap-index.xml
@@ -3,7 +3,9 @@
   <sitemap>
     <loc>https://www.petplace.com/sitemap.xml</loc>
   </sitemap>
+  <!-- Commented out until go-live
   <sitemap>
     <loc>https://www.example.com/sitemap-en-gb.xml</loc>
   </sitemap>
+   -->
 </sitemapindex>


### PR DESCRIPTION
Adds properly localized sitemaps:
- add a sitemap index listing all regional ones
- add a new helix query definition for the UK sitemap
- add a new helix sitemap definition for the UK sitemap

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/sitemap.xml
- After:
  - https://localized-sitemap--petplace--hlxsites.hlx.live/sitemap-index.xml
  - https://localized-sitemap--petplace--hlxsites.hlx.live/sitemap.xml
  - https://localized-sitemap--petplace--hlxsites.hlx.live/sitemap-en-gb.xml
