### PR TITLE
feat: refactor for ads on article side section

### DIFF
--- a/scripts/adsense.js
+++ b/scripts/adsense.js
@@ -35,6 +35,11 @@ export const adsDivCreator = (adLoc) => {
     footer.before(mainDiv);
   }
 
+  if (adLoc.includes('side')) {
+    const aside = document.querySelector('.social-share-wrapper');
+    aside.after(mainDiv);
+  }
+
   if (adLoc.includes('middle')) {
     if (adLoc.includes('home')) {
       const adSection = document

--- a/scripts/utils/helpers.js
+++ b/scripts/utils/helpers.js
@@ -186,25 +186,15 @@ export const mappingHelper = (adLoc) => {
     )
     .build();
 
+  // this conditional is only for articles
   if (adLoc.includes('article')) {
     if (adLoc.includes('side')) return mappingSide;
     if (adLoc.includes('middle')) return mappingMiddle;
   }
 
   if (adLoc.includes('top')) return mappingTop;
-  if (adLoc.includes('bottom')) return mappingLeaderboard;
-
+  // for everything else, it returns leaderboard
   return mappingLeaderboard;
-
-  // return adLoc.includes('top')
-  //   ? mappingTop
-  //   : adLoc.includes('side')
-  //     ? mappingSide
-  //     : adLoc.includes('middle')
-  //       ? mappingMiddle
-  //       : adLoc.includes('bottom')
-  //         ? mappingLeaderboard
-  //         : null;
 };
 
 export const sizingArr = (adLoc) => {
@@ -214,16 +204,9 @@ export const sizingArr = (adLoc) => {
 
   if (adLoc.includes('article')) {
     if (adLoc.includes('side')) return sizeSide;
-    if (adLoc.includes('top')) return sizeTopMid;
-    if (adLoc.includes('middle')) return sizeTopMid;
     if (adLoc.includes('bottom')) return sizeLeader;
+    return sizeTopMid;
   }
-
-  // return adLoc.includes('top') || adLoc.includes('middle')
-  //   ? sizeTopMid
-  //   : adLoc.includes('side')
-  //   ? sizeSide
-  //   : sizeLeader;
 
   return sizeLeader;
 };

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -985,7 +985,8 @@ main .section.search-container.ad-container .ad-wrapper .ad {
 }
 
 .social-share-container .publi-container {
-  position: -webkit-sticky; /* For Safari */
+  /* eslint-disable-next-line value-no-vendor-prefix */
+  position: -webkit-sticky;
   position: sticky;
   top: 0;
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -983,3 +983,13 @@ main .section.search-container.ad-container .ad-wrapper .ad {
 .publi-wrapper-multiplex {
   width: 100%;
 }
+
+.social-share-container .publi-container {
+  position: -webkit-sticky; /* For Safari */
+  position: sticky;
+  top: 0;
+}
+
+.social-share-container .publi-wrapper {
+  margin: 0;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -985,7 +985,7 @@ main .section.search-container.ad-container .ad-wrapper .ad {
 }
 
 .social-share-container .publi-container {
-  /* eslint-disable-next-line value-no-vendor-prefix */
+  /* stylelint-disable-next-line value-no-vendor-prefix */
   position: -webkit-sticky;
   position: sticky;
   top: 0;

--- a/templates/article-page/article-page.css
+++ b/templates/article-page/article-page.css
@@ -192,7 +192,7 @@
   }
 
   .article-page .article-author-container {
-    padding-top: 1rem;
+    padding: 1rem 0.5rem;
   }
 
   .article-page .category-link-btn {

--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -18,36 +18,6 @@ export async function getCategoryByKey(key, value) {
   return categories.find((c) => c[key].toLowerCase() === value.toLowerCase());
 }
 
-async function getRawCategoryAd(category) {
-  if (!category) {
-    return null;
-  }
-  if (category.Ad) {
-    return category.Ad;
-  }
-  if (!category['Parent Path']) {
-    return null;
-  }
-  const parent = await getCategoryByKey('Path', category['Parent Path']);
-  return getRawCategoryAd(parent);
-}
-
-/**
- * Retrieves the ID of the ad to show for a category. This will be determined
- * by the "Ad" column in the categories spreadsheet. The method will check
- * the ad column for the given category, and for all of that category's parents.
- *
- * If no ad is specified, the method will return a default ad.
- * @param {string} categorySlug Slug of the category whose ad should be
- *  retrieved.
- * @returns {Promise<string>} ID of an ad from the ads spreadsheet.
- */
-export async function getCategoryAd(categorySlug) {
-  const category = await getCategory(categorySlug);
-  const categoryAd = await getRawCategoryAd(category);
-  return categoryAd || 'article-default-rail';
-}
-
 function createAutoBlockSection(main, blockName, gridName) {
   const gridNameValue = gridName || blockName;
   const section = document.createElement('div');
@@ -132,18 +102,10 @@ async function getBreadcrumbs(categorySlug) {
 export async function loadEager(document) {
   const main = document.querySelector('main');
   createTemplateBlock(main, 'article-author');
-  createAutoBlockSection(main, 'ad', 'ad');
   createTemplateBlock(main, 'social-share');
   createTemplateBlock(main, 'popular-articles');
   createTemplateBlock(main, 'article-navigation');
   createTableOfContents(main);
-
-  const categorySlug = toClassName(getMetadata('category').split(',')[0]?.trim());
-  const ad = main.querySelector('.article-template-grid-ad');
-  const adId = document.createElement('div');
-  adId.innerText = await getCategoryAd(categorySlug);
-  const adBlock = buildBlock('ad', { elems: [adId] });
-  ad.append(adBlock);
 
   main.setAttribute('itemscope', '');
   const articleType = toClassName(getMetadata('type'));

--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -8,7 +8,6 @@ import {
 import {
   createBreadCrumbs,
   getCategories,
-  getCategory,
 } from '../../scripts/scripts.js';
 import { adsDefineSlot, adsDivCreator } from '../../scripts/adsense.js';
 import { pushToDataLayer } from '../../scripts/utils/helpers.js';

--- a/templates/article-page/article-page.js
+++ b/templates/article-page/article-page.js
@@ -215,11 +215,11 @@ export async function loadLazy(document) {
   breadcrumb.style.visibility = '';
 
   adsDivCreator('article_top');
+  adsDivCreator('article_side');
   adsDivCreator('article_middle');
   adsDivCreator('article_bottom');
 }
 
-// (side later with refactor)
 export async function loadDelayed() {
   const articleCat = toClassName(getMetadata('category').split(',')[0]?.trim());
   await pushToDataLayer({
@@ -231,6 +231,7 @@ export async function loadDelayed() {
   adsDefineSlot(
     [
       'article_top',
+      'article_side',
       'article_middle',
       'article_bottom',
       'article_anchor',


### PR DESCRIPTION
Branch Commits:
- sending article side to adsense script
- removed comments for helper file
- added condition to create div for side ad
- made the skyscraper sticky on scroll
- removed old setup for ads from blocks

Jira Issue:
https://pethealthinc.atlassian.net/browse/PM-88

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://feat-refactor-article-side-ads--petplace--hlxsites.hlx.live/
  - https://feat-refactor-article-side-ads--petplace--hlxsites.hlx.live/?martech=off

Screenshots:

full article view
![image](https://github.com/hlxsites/petplace/assets/146023473/3759da6b-0f66-4fab-a65c-93a5eaaade8c)

view on desktop
![image](https://github.com/hlxsites/petplace/assets/146023473/da0e3a92-e679-48f4-b9d7-553aa83f327c)

sticky while scrolling
![image](https://github.com/hlxsites/petplace/assets/146023473/32b7fcfa-bf7e-42c8-a7fa-1e9316f4140d)