### PR TITLE
feat: ads for breed guide and single breed pages

### DIFF
--- a/scripts/adsense.js
+++ b/scripts/adsense.js
@@ -1,4 +1,4 @@
-import { mappingHelper, sizingArr } from './utils/helpers.js';
+import { isMiddleAd, mappingHelper, sizingArr } from './utils/helpers.js';
 
 window.googletag ||= { cmd: [] };
 
@@ -162,7 +162,7 @@ const adsDefineSlot = async (adArgs, catVal) => {
 // google tag for adsense
 export const adsenseFunc = async (pageType, catVal) => {
   const boolArticle = pageType === 'article';
-  const boolMiddle = pageType !== 'category' || pageType !== 'tags';
+  const boolMiddle = isMiddleAd(pageType);
 
   if (catVal === 'create') {
     if (boolArticle) adsDivCreator(`${pageType}_side`);

--- a/scripts/adsense.js
+++ b/scripts/adsense.js
@@ -15,8 +15,16 @@ const adsDivCreator = (adLoc) => {
   subDiv.appendChild(adDiv);
 
   const idLoc = document.createElement('div');
-  idLoc.id = adLoc;
+  if (adLoc.includes('breeds')) {
+    const locSplice = adLoc.split('_');
+    idLoc.id = `breed_${locSplice[1]}`;
+  } else idLoc.id = adLoc;
   adDiv.appendChild(idLoc);
+
+  if (adLoc === 'article_side') {
+    const aside = document.querySelector('.social-share-wrapper');
+    aside.after(mainDiv);
+  }
 
   if (adLoc.includes('top')) {
     if (adLoc.includes('home')) {

--- a/scripts/adsense.js
+++ b/scripts/adsense.js
@@ -146,7 +146,7 @@ const adsDefineSlot = async (adArgs, catVal) => {
 // google tag for adsense
 export const adsenseFunc = async (pageType, catVal) => {
   const boolArticle = pageType === 'article';
-  const boolMiddle = pageType === 'home' || boolArticle;
+  const boolMiddle = pageType !== 'category' || pageType !== 'tags';
 
   if (catVal === 'create') {
     if (boolArticle) adsDivCreator(`${pageType}_side`);
@@ -157,14 +157,11 @@ export const adsenseFunc = async (pageType, catVal) => {
     return;
   }
 
-  const adsArr = [
-    `${pageType}_top`,
-    `${pageType}_bottom`,
-    `${pageType}_anchor`,
-  ];
+  const adPage = pageType === 'breeds' ? 'breed' : pageType;
+  const adsArr = [`${adPage}_top`, `${adPage}_bottom`, `${adPage}_anchor`];
 
-  if (boolArticle) adsArr.unshift(`${pageType}_side`);
-  if (boolMiddle) adsArr.unshift(`${pageType}_middle`);
+  if (boolArticle) adsArr.unshift(`${adPage}_side`);
+  if (boolMiddle) adsArr.unshift(`${adPage}_middle`);
 
   adsDefineSlot(adsArr, catVal);
 };

--- a/scripts/adsense.js
+++ b/scripts/adsense.js
@@ -32,6 +32,9 @@ const adsDivCreator = (adLoc) => {
         .querySelectorAll('.tiles-container')[0]
         .querySelectorAll('.default-content-wrapper')[0];
       adSection.before(mainDiv);
+    } else if (adLoc.includes('breeds')) {
+      const attrSection = document.querySelector('.blade-wrapper');
+      attrSection.before(mainDiv);
     } else {
       const hero = document.querySelector('.hero-wrapper');
       hero.after(mainDiv);
@@ -39,13 +42,13 @@ const adsDivCreator = (adLoc) => {
   }
 
   if (adLoc.includes('bottom')) {
-    const footer = document.querySelector('footer');
-    footer.before(mainDiv);
-  }
-
-  if (adLoc.includes('side')) {
-    const aside = document.querySelector('.social-share-wrapper');
-    aside.after(mainDiv);
+    if (adLoc.includes('breeds')) {
+      const refs = document.querySelector('.section.well');
+      refs.after(mainDiv);
+    } else {
+      const footer = document.querySelector('footer');
+      footer.before(mainDiv);
+    }
   }
 
   if (adLoc.includes('middle')) {
@@ -55,6 +58,11 @@ const adsDivCreator = (adLoc) => {
         .querySelectorAll('.default-content-wrapper')[1];
 
       adSection.before(mainDiv);
+    }
+
+    if (adLoc.includes('breeds')) {
+      const adSection = document.querySelector('.blade-container');
+      adSection.after(mainDiv);
     }
 
     if (adLoc.includes('article')) {

--- a/scripts/utils/helpers.js
+++ b/scripts/utils/helpers.js
@@ -210,3 +210,17 @@ export const sizingArr = (adLoc) => {
 
   return sizeLeader;
 };
+
+export const isMiddleAd = (type) => {
+  switch (type) {
+    case 'home':
+    case 'article':
+    case 'breeds':
+      return true;
+    case 'category':
+    case 'tags':
+    case 'breed':
+    default:
+      return false;
+  }
+};

--- a/templates/breed-index/breed-index.js
+++ b/templates/breed-index/breed-index.js
@@ -1,3 +1,4 @@
+import { adsenseFunc } from '../../scripts/adsense.js';
 import ffetch from '../../scripts/ffetch.js';
 import { buildBlock } from '../../scripts/lib-franklin.js';
 import { decorateResponsiveImages, getId, isTablet } from '../../scripts/scripts.js';
@@ -145,4 +146,10 @@ export async function loadLazy(document) {
       renderArticles(getArticles());
     });
   }
+
+  adsenseFunc('breed', 'create');
+}
+
+export function loadDelayed() {
+  adsenseFunc('breed');
 }

--- a/templates/breed-page/breed-page.css
+++ b/templates/breed-page/breed-page.css
@@ -36,6 +36,15 @@ main .section {
   padding: 5rem 1.5rem;
 }
 
+main .section.attributes-container,
+main .section.well {
+  padding: 2rem 1.5rem;
+}
+
+main .section.well .default-content-wrapper {
+  padding: 0;
+}
+
 main .section:nth-of-type(2n) {
   background: var(--background-color-light);
 }
@@ -44,10 +53,13 @@ main .section.centered p {
   text-align: left;
 }
 
-
 @media (min-width: 900px) {
   main .hero-container .hero {
     padding: 0 0 31.8182%;
+  }
+
+  main .section .blade-wrapper {
+    margin: 1rem auto;
   }
 }
 
@@ -61,5 +73,14 @@ main .section.centered p {
     padding-top: 245px;
     background: url('/images/cat_footer.png') no-repeat top center;
     background-size: 600px;
+  }
+
+  main .section.slide-cards-container .slide-card {
+    margin-bottom:50px;
+  }
+
+  main .care-tabs-container.section {
+    padding: 2rem 1.5rem;
+    margin-top: 2rem;
   }
 }

--- a/templates/breed-page/breed-page.js
+++ b/templates/breed-page/breed-page.js
@@ -1,7 +1,5 @@
-import {
-  getMetadata,
-  decorateIcons,
-} from '../../scripts/lib-franklin.js';
+import { adsenseFunc } from '../../scripts/adsense.js';
+import { getMetadata, decorateIcons } from '../../scripts/lib-franklin.js';
 
 // eslint-disable-next-line import/prefer-default-export
 export async function loadEager(document) {
@@ -19,4 +17,12 @@ export async function loadEager(document) {
   p.prepend(icon);
   await decorateIcons(p);
   h1.insertAdjacentElement('afterend', p);
+}
+
+export function loadLazy() {
+  adsenseFunc('breeds', 'create');
+}
+
+export function loadDelayed() {
+  adsenseFunc('breeds');
 }


### PR DESCRIPTION
Branch Commits:
- adsense setup for breeds pages (index/single)
- css modifications to allow for proper ads display
- modification to common func for different pages
- displaying breed slightly differently than others
- conditions for breed ads locations (top/middle/etc)
- helper function to better handle middle ad location
- checking adsense func if it's a page with middle ads

Jira Issue:
https://pethealthinc.atlassian.net/browse/PM-130

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://feat-breed-guide-ads--petplace--hlxsites.hlx.live/
  - https://feat-breed-guide-ads--petplace--hlxsites.hlx.live/?martech=off

Screenshot Samples:

-  Single Breed Desktop (top/bottom)
![image](https://github.com/hlxsites/petplace/assets/146023473/a3ab3a8b-e6f5-4512-9ead-4b7942cd78f5)
![image](https://github.com/hlxsites/petplace/assets/146023473/bcef4c51-f4ed-4cb6-bcf8-847afb32480d)

-  Single Breed Mobile (middle/anchor)
![image](https://github.com/hlxsites/petplace/assets/146023473/b1ac8967-5014-43a3-954e-854fb793fa52)

- Breed Index Desktop (top/bottom)
![image](https://github.com/hlxsites/petplace/assets/146023473/6943891d-74a5-4249-b092-5ee890ce537a)
![image](https://github.com/hlxsites/petplace/assets/146023473/8424dacb-6a46-4636-9cc9-e91738231940)

- Breed Index Mobile (top/anchor)
![image](https://github.com/hlxsites/petplace/assets/146023473/bf990b14-d2e9-4c17-ad49-84e9424d6880)

 
