### PR TITLE
fix: internal links should point to the localized page if it exists

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -432,6 +432,23 @@ function buildCookieConsent(main) {
   main.append(section);
 }
 
+function fixHyperLinks(main) {
+  // We only want to fix links on 'en' pages that are not the default US
+  if (!window.hlx.contentBasePath || !document.documentElement.lang.startsWith('en-')) {
+    return;
+  }
+  [...main.querySelectorAll('a[href]')]
+    .filter((a) => !a.href.startsWith(window.hlx.contentBasePath))
+    .forEach(async (a) => {
+      const newURL = `${window.hlx.contentBasePath}${new URL(a.href).pathname}`;
+      // If the localized version of the page exists, let's point to it instead of the US page
+      const resp = await fetch(newURL, { method: 'HEAD' });
+      if (resp.ok) {
+        a.href = `${window.hlx.contentBasePath}${new URL(a.href).pathname}`;
+      }
+    });
+}
+
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
@@ -442,6 +459,7 @@ function buildAutoBlocks(main) {
     buildEmbedBlocks(main);
     buildHyperlinkedImages(main);
     buildCookieConsent(main);
+    fixHyperLinks(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);


### PR DESCRIPTION
All internal page links on the UK pages that point to US pages should be redirected to their UK alternative if it exists.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://fix-localized-links--petplace--hlxsites.hlx.live/en-gb/
  - https://fix-localized-links--petplace--hlxsites.hlx.live/en-gb/?martech=off
