### PR TITLE
[PPAD-291] [QA] - Main Navigation - The "Pet Articles" tab in the menu does not look set in Safari browser

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -102,6 +102,9 @@
   height: 48px;
   border-radius: 360px;
   padding-left: 16px;
+  appearance: none;
+  -webkit-appearance: none;
+  border-color: #000000;
 }
 
 #nav .header-wrapper.search-input::placeholder {
@@ -176,7 +179,8 @@
 
 #nav .menu-item {
   box-sizing: border-box;
-  display: block;
+  display: flex;
+  justify-content: space-between;
   color: #000000;
   font-family: "Libre Franklin";
   font-size: 18px;
@@ -209,7 +213,7 @@
   font-size: 20px;
   color: #000000;
   float: right;
-  transform: rotate(180deg) translateY(6px);
+  transform: rotate(180deg) translateY(2px);
 }
 
 #nav .collapsible.active {


### PR DESCRIPTION
Fixes for search input and collapsible elements styles on safari

![Screenshot 2024-03-21 at 20 09 20](https://github.com/hlxsites/petplace/assets/161368342/88f9539e-ab31-4532-ae7d-5b3cff26db80)


Test URLs:
http://localhost:3000/