### PR TITLE
fix: load marked only when needed

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -29,16 +29,6 @@ function isPopoverSupported() {
   return HTMLElement.prototype.hasOwnProperty('popover');
 }
 
-loadScript('https://cdn.jsdelivr.net/npm/marked/marked.min.js', () => {
-  console.log('Marked.js loaded');
-});
-loadScript('https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js', () => {
-  console.log('Masonry.js loaded');
-});
-loadScript('https://unpkg.com/imagesloaded@5/imagesloaded.pkgd.min.js', () => {
-  console.log('ImagesLoaded.js loaded');
-});
-
 /**
  * decorates the header, mainly the nav
  * @param {Element} block The header block element
@@ -54,7 +44,7 @@ export default async function decorate(block) {
     navMeta = getMetadata('mega-nav');
     navPath = navMeta ? new URL(navMeta).pathname : `${window.hlx.contentBasePath}/fragments/mega-nav`;
     resp = await fetch(`${navPath}.plain.html`);
-  
+
     if (!resp.ok) {
       return;
     }

--- a/templates/gen-ai/gen-ai.js
+++ b/templates/gen-ai/gen-ai.js
@@ -1,3 +1,4 @@
+import { loadScript } from '../../scripts/lib-franklin.js';
 import {
   Events,
   decorateSlideshowAria,
@@ -522,6 +523,7 @@ export function setupSearchResults(defaultContentWrapper) {
 }
 
 export async function loadLazy(main) {
+  await loadScript('https://cdn.jsdelivr.net/npm/marked/marked.min.js');
   const hero = document.createElement('div');
   const imgDiv = document.createElement('div');
   const contentDiv = document.createElement('div');


### PR DESCRIPTION
Move the global reference in the header to the dedicated template to reduce performance impact.
Also remove unused dependencies.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.live/discovery
- After:
  - https://fix-marked-loading--petplace--hlxsites.hlx.live/discovery
  - https://fix-marked-loading--petplace--hlxsites.hlx.live/discovery?martech=off
