### PR TITLE
Adding API error logging for adoption user creation

### DIFF
--- a/scripts/lib/msal/msal-authentication.js
+++ b/scripts/lib/msal/msal-authentication.js
@@ -5,6 +5,7 @@ import { loginRequest, logoutRequest, tokenRequest, changePwdRequest, msalConfig
 import { isMobile } from '../../scripts.js';
 import endPoints from '../../../variables/endpoints.js';
 import { pushToDataLayer } from '../../utils/helpers.js';
+import { captureError } from '../../scripts.js';
 
 let cachedMsalInstance = null;
 let cachedMsalChangePwdInstance = null;
@@ -298,23 +299,25 @@ function handleResponse(response, customCallback, featureName = 'PetPlace (Gener
                     : 'N/A - Content Group Not Set'
                   });
 
-                // invoke custom callback if one was provided
-                if (customCallback) {
-                    customCallback(response);
-                }
-            })
-            .catch((error) => {
-                console.error('/adopt/api/User Error:', error);
-            });
-        } else {
-            pushToDataLayer({
-                event: 'login',
-                user_id: response.account.localAccountId,
-                user_type: 'member',
-                content_group: contentGroup
-                ? contentGroup.content
-                : 'N/A - Content Group Not Set'
-              });
+          // invoke custom callback if one was provided
+          if (customCallback) {
+            customCallback(response);
+          }
+        })
+        .catch((error) => {
+          captureError('account creation', error);
+          // eslint-disable-next-line no-console
+          console.error('/adopt/api/User Error:', error);
+        });
+    } else {
+      pushToDataLayer({
+        event: 'login',
+        user_id: response.account.localAccountId,
+        user_type: 'member',
+        content_group: contentGroup
+          ? contentGroup.content
+          : 'N/A - Content Group Not Set',
+      });
 
             // invoke custom callback if one was provided
             if (customCallback) {

--- a/scripts/lib/msal/msal-authentication.js
+++ b/scripts/lib/msal/msal-authentication.js
@@ -308,6 +308,36 @@ function handleResponse(response, customCallback, featureName = 'PetPlace (Gener
           captureError('account creation', error);
           // eslint-disable-next-line no-console
           console.error('/adopt/api/User Error:', error);
+          // trying a second time in case of a network error
+          fetch(`${endPoints.apiUrl}/adopt/api/User`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${response.accessToken}`,
+            },
+            // eslint-disable-next-line no-useless-escape
+            body: featureName ? '\"' + featureName + '\"' : null,
+          })
+            .then(() => {
+              pushToDataLayer({
+                event: 'sign_up',
+                user_id: response.account.localAccountId,
+                user_type: 'member',
+                content_group: contentGroup
+                  ? contentGroup.content
+                  : 'N/A - Content Group Not Set',
+              });
+    
+              // invoke custom callback if one was provided
+              if (customCallback) {
+                customCallback(response);
+              }
+            })
+            .catch((error) => {
+              captureError('account creation', error);
+              // eslint-disable-next-line no-console
+              console.error('/adopt/api/User Error:', error);
+            });
         });
     } else {
       pushToDataLayer({


### PR DESCRIPTION
Adding logging for adoption user creation api
Adding additional retry for when user creation api fails

Isolating this update from other PR to expedite getting this logging into production

Test URLs:
- Before: https://www.petplace.com/
- After:
  - https://hero-develop--petplace--hlxsites.hlx.page/
  - https://hero-develop--petplace--hlxsites.hlx.page/?martech=off
