### PR TITLE
PPAD-411: track change events also in renderAsNonUser survey summary

### DIFF
--- a/blocks/pet-survey/pet-survey.js
+++ b/blocks/pet-survey/pet-survey.js
@@ -170,6 +170,10 @@ export default async function decorate(block) {
           QuestionOptionId: parseInt(el.target.value, 10),
         };
         state.surveyAnswers.push(data);
+        const saveBtn = block.querySelector('#pet-survey-summary-save');
+        if (saveBtn.disabled) {
+          saveBtn.disabled = false;
+        }
         const otherOptions = inputEl.querySelectorAll(`option:not([value="${el.target.value}"]):not([value=""])`);
         if (otherOptions.length > 0) {
           otherOptions.forEach((option) => {
@@ -576,10 +580,9 @@ export default async function decorate(block) {
         if (accountWrapper) {
           const surveySuccessMessage = accountWrapper.querySelector('.pet-survey__success-message');
           surveySuccessMessage.classList.add('show');
-          const saveBtn = block.querySelector('#pet-survey-summary-save');
-
-          saveBtn.disabled = true;
         }
+        const saveBtn = block.querySelector('#pet-survey-summary-save');
+        saveBtn.disabled = true;
       }
     } catch (error) {
       // eslint-disable-next-line

--- a/blocks/pet-survey/pet-survey.js
+++ b/blocks/pet-survey/pet-survey.js
@@ -584,7 +584,7 @@ export default async function decorate(block) {
           surveySuccessMessage.classList.add('show');
         }
         const saveBtn = block.querySelector('#pet-survey-summary-save');
-        saveBtn.disabled = true;
+        if (saveBtn) saveBtn.disabled = true;
       }
     } catch (error) {
       // eslint-disable-next-line
@@ -697,7 +697,7 @@ export default async function decorate(block) {
         await createSummaryForm(animalType, questions, animalId, clientId),
       ),
     );
-
+    bindSurveySummaryChangeEvents();
     block
       .querySelector('form.pet-survey__form')
       .addEventListener('submit', (event) => {

--- a/blocks/pet-survey/pet-survey.js
+++ b/blocks/pet-survey/pet-survey.js
@@ -158,6 +158,11 @@ export default async function decorate(block) {
       });
     });
   }
+  function enableSaveButton() {
+    // Get save button
+    const saveBtn = block.querySelector('#pet-survey-summary-save');
+    if (saveBtn.disabled) saveBtn.disabled = false;
+  }
   function bindSurveySummaryChangeEvents() {
     // Selects
     const surveyInputs = block.querySelectorAll(
@@ -170,10 +175,7 @@ export default async function decorate(block) {
           QuestionOptionId: parseInt(el.target.value, 10),
         };
         state.surveyAnswers.push(data);
-        const saveBtn = block.querySelector('#pet-survey-summary-save');
-        if (saveBtn.disabled) {
-          saveBtn.disabled = false;
-        }
+        enableSaveButton();
         const otherOptions = inputEl.querySelectorAll(`option:not([value="${el.target.value}"]):not([value=""])`);
         if (otherOptions.length > 0) {
           otherOptions.forEach((option) => {
@@ -208,7 +210,7 @@ export default async function decorate(block) {
             ExternalAnswerKey: el.target.getAttribute('data-option-id'),
             UserResponseText: el.target.getAttribute('data-option-text'),
           };
-
+          enableSaveButton();
           // add the checked item to the state
           if (el.target.checked) {
             state.surveyAnswers.push(data);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #PPAD-411:

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://<branch>--petplace--hlxsites.hlx.live/
  - https://<branch>--petplace--hlxsites.hlx.live/?martech=off
