### PR TITLE
feat(PM-331): Add breadcrumbs to Insurance Pages

### DIFF
--- a/icons/chevron-large.svg
+++ b/icons/chevron-large.svg
@@ -1,0 +1,4 @@
+<svg fill="none" viewBox="0 0 16 17" xmlns="http://www.w3.org/2000/svg">
+    <path d="m3.667 1 7.1467 7.1467c0.0464 0.04637 0.0832 0.10145 0.1084 0.16208 0.0251 0.06063 0.0381 0.12562 0.0381 0.19125s-0.013 0.13062-0.0381 0.19125c-0.0252 0.06063-0.062 0.11571-0.1084 0.16208l-7.1467 7.1467" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+</svg>
+

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1089,7 +1089,8 @@ export function initializeTouch(block, slideWrapper) {
  * @param {Array<CrumbData>} crumbData Information about the crumbs to add.
  * @returns {Promise<Element>} Resolves with the crumb element.
  */
-export async function createBreadCrumbs(crumbData, chevronAll = false) {
+export async function createBreadCrumbs(crumbData, options = {}) {
+  const { chevronAll = false, chevronIcon = 'chevron', useHomeLabel = false } = options;
   const { color } = crumbData[crumbData.length - 1];
   const breadcrumbContainer = document.createElement('nav');
   breadcrumbContainer.setAttribute('aria-label', getPlaceholder('breadcrumb'));
@@ -1099,8 +1100,16 @@ export async function createBreadCrumbs(crumbData, chevronAll = false) {
   const homeLi = document.createElement('li');
   const homeLink = document.createElement('a');
   homeLink.href = window.hlx.contentBasePath || '/';
-  homeLink.innerHTML = '<span class="icon icon-home"></span>';
-  homeLink.setAttribute('aria-label', getPlaceholder('logoLinkLabel'));
+  if (useHomeLabel) {
+    homeLink.innerText = getPlaceholder('homeNavigation');
+    homeLink.classList.add('category-link-btn');
+    homeLink.style.setProperty('--bg-color', 'var(--background-color)');
+    homeLink.style.setProperty('--border-color', `var(--color-${color})`);
+    homeLink.style.setProperty('--text-color', `var(--color-${color})`);
+  } else {
+    homeLink.innerHTML = '<span class="icon icon-home"></span>';
+    homeLink.setAttribute('aria-label', getPlaceholder('logoLinkLabel'));
+  }
   homeLi.append(homeLink);
   ol.append(homeLi);
 
@@ -1108,7 +1117,7 @@ export async function createBreadCrumbs(crumbData, chevronAll = false) {
     const li = document.createElement('li');
     if (i > 0 || chevronAll) {
       const chevron = document.createElement('span');
-      chevron.classList.add('icon', 'icon-chevron');
+      chevron.classList.add('icon', `icon-${chevronIcon}`);
       li.append(chevron);
     }
     const linkButton = document.createElement('a');

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -82,6 +82,7 @@
   --color-magenta-transparent: rgb(169 77 143 / 60%);
   --color-mauve-transparent: rgb(106 55 90 / 60%);
   --color-neutral-300: #e4e4e7;
+  --color-neutral-600: #6e6d73;
 
   /* fonts */
   --body-font-family: 'Libre Franklin', 'Libre Franklin Fallback', sans-serif;

--- a/templates/author-page/author-page.js
+++ b/templates/author-page/author-page.js
@@ -85,7 +85,7 @@ export async function loadEager(document) {
     path: heading.innerText,
     color: 'purple',
     label: heading.innerText,
-  }], true);
+  }], { chevronAll: true });
   createTemplateBlock(main, 'breadcrumb', 'breadcrumb', [breadcrumbData]);
   createTemplateBlock(main, 'social-links');
   createTemplateBlock(main, 'cards');

--- a/templates/insurance-page/insurance-page.css
+++ b/templates/insurance-page/insurance-page.css
@@ -111,6 +111,56 @@
   margin-bottom: 0;
 }
 
+/* Breadcrumbs */
+.insurance-page .breadcrumb-wrapper {
+  max-width: 1200px;
+  margin: 1.5rem auto 0.5rem;
+  padding: 0 1rem;
+
+  @media (max-width: 1023px) {
+    display: none;
+  }
+}
+
+.insurance-page .breadcrumb ol {
+  column-gap: 0.5rem;
+  margin: 0;
+}
+
+.insurance-page .breadcrumb ol li {
+  column-gap: 0.5rem;
+}
+
+.insurance-page .breadcrumb ol li:first-child {
+  margin-right: 0;
+}
+
+.insurance-page .breadcrumb .icon-chevron-large {
+  fill: var(--color-black);
+  width: 16px;
+  height: 16px;
+}
+
+.insurance-page .breadcrumb .category-link-btn {
+  background: unset;
+  border: none;
+  border-radius: unset;
+  display: -webkit-box;
+  max-width: 150px;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  flex-shrink: 0;
+  font-size: var(--body-font-size-s);
+  line-height: normal;
+  text-align: left;
+  text-decoration: none;
+  padding: 0;
+}
+
+.insurance-page .breadcrumb .category-link-btn[aria-current="page"] {
+  color: var(--color-neutral-600);
+}
+
 /* Tables */
 .insurance-page .table table {
   table-layout: fixed;

--- a/templates/insurance-page/insurance-page.js
+++ b/templates/insurance-page/insurance-page.js
@@ -3,6 +3,7 @@ import {
   decorateBlock,
   loadBlock,
 } from '../../scripts/lib-franklin.js';
+import { createBreadCrumbs } from '../../scripts/scripts.js';
 
 async function createTemplateBlock(container, blockName, elems = []) {
   const wrapper = document.createElement('div');
@@ -54,6 +55,29 @@ export async function loadEager(document) {
 }
 
 export async function loadLazy(document) {
+  // Create breadcrumbs
+  const main = document.querySelector('main');
+  const body = main.parentNode;
+  const breadcrumbContainer = document.createElement('div');
+  body.insertBefore(breadcrumbContainer, main);
+
+  const heading = main.querySelector('h1');
+  const breadcrumbData = await createBreadCrumbs([{
+    url: `${window.hlx.contentBasePath}/pet-insurance`,
+    path: 'Pet Insurance',
+    color: 'black',
+    label: 'Pet Insurance',
+  }, {
+    url: window.location,
+    path: heading.innerText,
+    color: 'black',
+    label: heading.innerText,
+  }], { chevronAll: true, chevronIcon: 'chevron-large', useHomeLabel: true });
+  breadcrumbData.querySelectorAll('.icon.icon-chevron').forEach((icon) => {
+    icon.classList.replace('icon-chevron', 'icon-chevron-large');
+  });
+  createTemplateBlock(breadcrumbContainer, 'breadcrumb', [breadcrumbData]);
+
   // Adjust structure of article author for styling
   const authorContainer = document.querySelector('.article-author [itemprop="author"]');
   const timePublished = document.querySelector('.article-author [itemprop="datePublished"]');


### PR DESCRIPTION
Adjust createBreadcrumb to support new options

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix: [PM-331](https://pethealthinc.atlassian.net/browse/PM-331)

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/pet-insurance/best-pet-insurance-california
- After:
  - https://feat-insurance-page-breadcrumb--petplace--hlxsites.hlx.page/pet-insurance/best-pet-insurance-california
  - https://feat-insurance-page-breadcrumb--petplace--hlxsites.hlx.page/pet-insurance/best-pet-insurance-california?martech=off
