### PR TITLE
[PPAD-408] Confirmation screen text trimmed on mobile

### DIFF
--- a/blocks/pet-survey/pet-survey.css
+++ b/blocks/pet-survey/pet-survey.css
@@ -32,6 +32,10 @@ main .pet-survey-container {
   flex-direction: row;
   gap: 16px;
   margin-top: 24px;
+  @media screen and (max-width: 461px) {
+    flex-direction: column-reverse;
+    align-items: center;
+  }
 }
 a.pet-survey__button,
 button.pet-survey__button {
@@ -43,6 +47,9 @@ button.pet-survey__button {
   font-family: var(--body-font-family);
   font-size: 18px;
   line-height: 1.2;
+  @media screen and (max-width: 461px) {
+    width: 100%;
+  }
 }
 .pet-survey__button.primary {
   background-color: var(--orange-300, #c74d2f);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #PPAD-408

Test URLs:
http://localhost:3000/pet-adoption/survey?animalId=30779404&clientId=PP2528&animalType=dog

![image](https://github.com/hlxsites/petplace/assets/169208521/df472daf-7306-42fa-8ec6-ea73bba1f32f)

