### PR TITLE
[SITES-22691] Use "audiences" checkpoint to track language and region in RUM data

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -36,7 +36,46 @@ const AUDIENCES = {
 
 export const DEFAULT_REGION = 'en-US';
 export const REGIONS = {
-  'en-GB': ['LCY', 'LHR', 'LON', 'MAN'],
+  // Africa:
+  en_GH: ['ACC'],
+  en_ZA: ['CPT', 'JNB'],
+  // North America:
+  en_CA: ['YUL', 'YVR', 'YYC', 'YYZ'],
+  en_US: ['ADS', 'BFI', 'BOS', 'BUR', 'CHI', 'CMH', 'DCA', 'DEN', 'DFW', 'DTW', 'EWR', 'GNV', 'HNL', 'IAD', 'IAH', 'LAX', 'LCK', 'LGA', 'MCI', 'MIA', 'MSP', 'NYC', 'PAO', 'PDK', 'PDX', 'PHX', 'SJC', 'STL', 'STP', 'WVI'],
+  // South America:
+  es_AR: ['EZE'],
+  es_BR: ['CWB', 'FOR', 'GIG', 'GRU'],
+  es_CL: ['SCL'],
+  es_CO: ['BOG'],
+  es_PE: ['LIM'],
+  // Asia:
+  ko_KR: ['ICN'],
+  ar_AE: ['DXB', 'FJR'],
+  en_PH: ['MNL'],
+  en_SG: ['QPG'],
+  en_IN: ['BOM', 'CCU', 'DEL', 'HYD', 'MAA'],
+  ja_JP: ['HND', 'ITM', 'NRT', 'TYO'],
+  ms_MY: ['KUL'],
+  th_TH: ['BKK'],
+  zh_HK: ['HKG'],
+  // Europe:
+  bg_BG: ['SOF'],
+  da_DK: ['CPH'],
+  de_AT: ['VIE'],
+  de_DE: ['FRA', 'MUC', 'WIE'],
+  en_GB: ['LCY', 'LHR', 'LON', 'MAN'],
+  es_ES: ['MAD'],
+  fi_FI: ['HEL'],
+  fr_BE: ['BRU'],
+  fr_FR: ['PAR', 'MRS'],
+  ga_IE: ['DUB'],
+  it_IT: ['FCO', 'LIN', 'MXP', 'PMO'],
+  nl_NL: ['AMS'],
+  pt_PT: ['LIS'],
+  sv_SE: ['BMA', 'OSL'],
+  // Oceania:
+  en_AU: ['ADL', 'BNE', 'MEL', 'PER', 'SYD'],
+  en_NZ: ['AKL', 'CHC', 'WLG'],
 };
 
 window.hlx.templates.add([
@@ -1002,15 +1041,9 @@ async function loadLazy(doc) {
   sampleRUM('lazy');
   sampleRUM.observe(main.querySelectorAll('div[data-block-name]'));
   sampleRUM.observe(main.querySelectorAll('picture > img'));
-  sampleRUM('lang', { source: document.documentElement.lang, target: navigator.languages.join(',') });
-  const getRegionPromise = getRegion();
-  getRegionPromise
-    .then((region) => {
-      sampleRUM('region', { source: region });
-    })
-    .catch((error) => {
-      captureError('Error fetching region:', error);
-    });
+  sampleRUM('audiences', { source: 'page-language', target: document.documentElement.lang });
+  sampleRUM('audiences', { source: 'preferred-languages', target: navigator.languages.join(',') });
+  getRegion().then((region) => sampleRUM('audiences', { source: 'user-region', target: region }));
 
   await window.hlx.plugins.run('loadLazy');
 


### PR DESCRIPTION
Using "audiences" checkpoint to send language and region data and expand the default region mapping list.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://22691-update-default-region-map--petplace--hlxsites.hlx.live/
  - https://22691-update-default-region-map--petplace--hlxsites.hlx.live/?martech=off
