### PR TITLE
hotfix: Prevent 404 error on default page for category and tags

### DIFF
--- a/templates/category-index/category-index.js
+++ b/templates/category-index/category-index.js
@@ -137,6 +137,12 @@ function createTemplateBlock(main, blockName, elems = []) {
 }
 
 async function updateMetadata() {
+  // We're skipping validation for default template pages
+  // to allow publishing new template updates
+  const defaultPages = ['/article/category/default', '/tags/default'];
+  if (defaultPages.find((path) => path === window.location.pathname)) {
+    return;
+  }
   const result = await getCategoryOrTagForUrl();
   if (!result) {
     throw new Error(404);


### PR DESCRIPTION
Error is preventing publishing authoring changes

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix: [PM-277](https://pethealthinc.atlassian.net/browse/PM-277)

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/article/category/default
- After:
  - https://hotfix-category-tags-default--petplace--hlxsites.hlx.page/article/category/default
  -   - https://hotfix-category-tags-default--petplace--hlxsites.hlx.page/article/category/default?martech=off
