### PR TITLE
fix: GenAI - Hero Image Crop

### DIFF
--- a/templates/gen-ai/gen-ai.css
+++ b/templates/gen-ai/gen-ai.css
@@ -3,50 +3,59 @@
 }
 
 .gen-ai .hero-wrapper {
+  display: grid;
   position: relative;
   max-width: inherit;
   flex-direction: row;
-  position: relative;
-  max-height: 375px;
   overflow: hidden;
+
+  @media (max-width: 1023px) {
+    max-height: 375px;
+  }
 }
 
 .gen-ai .hero-wrapper .img-div {
   position: relative;
-  padding-bottom: 90%;
-  @media (max-width: 1024px){
-    padding-bottom: 70%;
+  grid-column: 1 / 2;
+  grid-row: 1 / 2;
+
+  @media (max-width: 1024px) {
     height: 100%;
   }
 }
 
 .gen-ai .hero-wrapper .img-div img {
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
-  height: 100%;
   max-height: 375px;
   object-fit: cover;
   object-position: center center;
   opacity: 1;
   transition: opacity 500ms ease 0s;
-  @media (max-width: 1024px){
+
+  @media (max-width: 1024px) {
     object-position: top left;
   }
-  @media (min-width: 1400px){
+
+  @media (min-width: 1024px) {
+    min-height: 446px;
+  }
+
+  @media (min-width: 1400px) {
     object-position: bottom center;
   }
 }
 
 .gen-ai .hero-wrapper .text-div {
-  position: absolute;
-  inset: 0 1.5rem;
+  grid-column: 1 / 2;
+  grid-row: 1 / 2;
+  position: relative;
+  z-index: 2;
+  justify-self: center;
   display: flex;
   flex-direction: column;
-  color: var(--text-color-inverted);
+  width: calc(100% - 3rem);
   max-width: 1392px;
-  margin: 0 auto;
+  color: var(--text-color-inverted);
 }
 
 .gen-ai .hero-wrapper .text-div h1 {
@@ -63,10 +72,9 @@
   display: inline-block;
   margin-right: 5px;
   background-size: cover;
-
 }
 @media (min-width: 600px) {
-.gen-ai .hero-wrapper .text-div h1:before {
+  .gen-ai .hero-wrapper .text-div h1:before {
     height: 58px;
     width: 58px;
   }
@@ -76,7 +84,7 @@
 }
 
 .gen-ai .sortbtn .search-select {
-  padding: 1px 2.5rem 2px 1rem;        
+  padding: 1px 2.5rem 2px 1rem;
   background-image: url('../../icons/down-chevron.svg');
   background-position: calc(100% - 13px) 50%;
   background-repeat: no-repeat;
@@ -92,7 +100,7 @@
 .gen-ai .cards .skeleton {
   min-width: 318px;
 }
-@media (max-width: 600px){
+@media (max-width: 600px) {
   .gen-ai .hero-wrapper .text-div p {
     font-size: 0.8125rem;
   }
@@ -106,7 +114,6 @@
 @media screen and (min-width: 530px) {
   .gen-ai .hero-wrapper .img-div {
     position: relative;
-    padding-bottom: 62%;
   }
 }
 
@@ -138,10 +145,5 @@
 @media (min-width: 1200px) {
   .gen-ai .section > div.hero-wrapper {
     max-width: inherit;
-  }
-
-  .gen-ai .hero-wrapper .img-div {
-    position: relative;
-    padding-bottom: 30.2083%;
   }
 }


### PR DESCRIPTION
**Issue:** The hero image gets cropped from top when you go to wider screens (or zoom out). Refer to ticket for expected image visual presentation.

Fix: [PM-224](https://pethealthinc.atlassian.net/browse/PM-224)

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/discovery
- After:
https://bugfix-genai-hero-image-crop--petplace--hlxsites.hlx.page/discovery
https://bugfix-genai-hero-image-crop--petplace--hlxsites.hlx.page/discovery/?martech=off
