### PR TITLE
Adding AdExchange ads.txt code for Open Bidding

### DIFF
--- a/ads.txt
+++ b/ads.txt
@@ -1,5 +1,7 @@
-# ads.txt (last update: 21-06-2024)
+# ads.txt (last update: 07-31-2024)
 # OFFICIAL PETPLACE Ad Sense
 google.com, pub-0827704052812365, DIRECT, f08c47fec0942fa0
 # OFFICIAL PETPLACE Ad Exchange
 google.com, pub-5915072357508663, DIRECT, f08c47fec0942fa0
+#IndexExchange OB
+indexexchange.com, 209361, DIRECT, 50b1c356f2c5c8fc


### PR DESCRIPTION
# Update ads.txt file

We are from .Monks and work with the Petplace team on site monetization (primarily creating and managing ad units).

This change to the ads.txt file is to add a new partner to the Open Auction for ads. For more information, you can read about it [here](https://support.google.com/admanager/answer/7128453?hl=en).

## Changes made:
- Added new partner (AdExchange) code to ads.txt for Open Auction participation

## Impact:
- Enhances ad revenue potential
- No negative impact on site performance or user experience

Please review and let us know if you have any questions.