### PR TITLE
fix: Breed Category - Pagination

### DIFF
--- a/blocks/pagination/pagination.js
+++ b/blocks/pagination/pagination.js
@@ -22,12 +22,13 @@ function renderContent(block) {
   const total = Number.isNaN(Number(block.getAttribute('data-total')))
     ? block.getAttribute('data-total')
     : Math.ceil(Number(block.getAttribute('data-total')) / limit);
+
   block.innerHTML = `
     <nav aria-label="pagination">
       <ul>
         ${page > 1 ? `<li><a href="${window.location.pathname}?${prevParams}" aria-label="${getPlaceholder('previousPage')}"><span class="icon icon-chevron-wide"></span></a></li>` : ''}
         <li><a href="#" aria-current="page" tabindex="-1">${getPlaceholder('pageIndex', { page, total: total || '…' })}</a></li>
-        ${cards?.childElementCount >= limit ? `<li><a href="${window.location.pathname}?${nextParams}" aria-label="${getPlaceholder('nextPage')}"><span class="icon icon-chevron-wide"></span></a></li>` : ''}
+        ${cards?.childElementCount >= limit && page < total ? `<li><a href="${window.location.pathname}?${nextParams}" aria-label="${getPlaceholder('nextPage')}"><span class="icon icon-chevron-wide"></span></a></li>` : ''}
       </ul>
     </nav>`;
   if (page > 1 && !document.head.querySelector('link[rel="prev"]')) {


### PR DESCRIPTION
**Issue:** When on the Breed Category [page](https://www.petplace.com/article/breed/?page=12) -> it shows 12 pages in the pagination. However users are able to proceed past that, to the 13th page, which is shown as empty.

Fix: [PM-460](https://pethealthinc.atlassian.net/browse/PM-460)

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/article/breed/?page=12
- After:
  - https://bugfix-breed-category-pagination--petplace--hlxsites.hlx.page/article/breed/?page=12
  - https://bugfix-breed-category-pagination--petplace--hlxsites.hlx.page/article/breed/?page=12/?martech=off
