### PR TITLE
chore(perf): fix the CLS on the breed index pages

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -271,3 +271,22 @@
     24px 320px,
     24px 345px;
 }
+
+.cards.breed .skeleton {
+  min-height: 343px;
+  background-image:
+    linear-gradient(var(--color-gray-light-alt) 128px, transparent 0),
+    linear-gradient(var(--color-gray-light-alt) 24px, transparent 0),
+    linear-gradient(var(--color-gray-light-alt) 24px, transparent 0),
+    linear-gradient(var(--color-gray-light-alt) 24px, transparent 0);
+  background-size:
+    100% 128px,
+    calc(100% - 2*24px) 24px,
+    calc(100% - 2*24px) 24px,
+    calc(100% - 2*24px) 24px;
+  background-position:
+    0 0,
+    24px 158px,
+    24px 188px,
+    24px 218px;
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -692,6 +692,12 @@ function animateSkeletons(main) {
           .forEach((el) => {
             observer.observe(el);
           });
+        [...entry.addedNodes]
+          .map((el) => (el.querySelectorAll ? [...el.querySelectorAll('.skeleton')] : []))
+          .flat()
+          .forEach((el) => {
+            observer.observe(el);
+          });
       } else if (entry.target.classList?.contains('skeleton')) {
         observer.observe(entry.target);
       }

--- a/templates/breed-index/breed-index.css
+++ b/templates/breed-index/breed-index.css
@@ -6,6 +6,15 @@
     position: relative;
 }
 
+.hero-wrapper .hero {
+  padding: 0;
+  min-height: auto;
+}
+
+.hero-wrapper .hero h1 {
+  color: var(--text-color-inverted);
+}
+
 .hero-wrapper .img-div {
     position: relative;
     padding-bottom: 111%;
@@ -21,6 +30,7 @@
     object-position: center center;
     opacity: 1;
     transition: opacity 500ms ease 0s;
+    max-height: auto;
 }
 
 .hero-wrapper .text-div {
@@ -84,16 +94,22 @@
 }
 
 @media screen and (min-width: 461px) {
-    .hero-wrapper .img-div {
-        position: relative;
-        padding-bottom: 62%;
-    }
+  .hero-wrapper .img-div {
+    position: relative;
+    padding-bottom: 62%;
+  }
 }
 
 @media screen and (min-width: 768px) {
-    .hero-wrapper .text-div {
-        top: 60px
-    }
+  .hero-wrapper .text-div {
+    top: 60px
+  }
+}
+
+@media screen and (min-width: 900px) {
+  .hero-wrapper .hero h1 {
+    font-size: var(--heading-font-size-xxl);
+  }
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
## Issue

The current breed index page has seen a drop in performance recently. We'll focus on fixing the CLS, as the TBT is mostly caused by the martech stack.

| Mobile | Desktop |
|-|-|
| <img width="963" alt="Screenshot 2024-08-02 at 15 10 28" src="https://github.com/user-attachments/assets/c3093e93-0e97-4833-aaa6-4ea775703aa3"> | <img width="965" alt="Screenshot 2024-08-02 at 15 10 35" src="https://github.com/user-attachments/assets/c3ab267d-4fe5-4e7d-b162-d8de331c7918"> |

## Root cause

As we can see in the performance audit, we have mainly 3 layout shifts:
<img width="1229" alt="Screenshot 2024-08-02 at 15 29 56" src="https://github.com/user-attachments/assets/9c0d8dcb-6f43-4488-83d5-6f629821f157">

With respectively:
<img width="560" alt="Screenshot 2024-08-02 at 15 30 28" src="https://github.com/user-attachments/assets/1c211c5b-f1cd-461f-b733-71e8bf9c6ec8">
<img width="557" alt="Screenshot 2024-08-02 at 15 30 40" src="https://github.com/user-attachments/assets/0eb528ad-ad25-4d73-ace5-e1cc695a1849">
<img width="561" alt="Screenshot 2024-08-02 at 15 30 47" src="https://github.com/user-attachments/assets/7af45c8f-b766-4ba5-aa37-f24d06466a7a">

This hints at:
1. The filters are shifted by something injected before it, after it rendered (i.e. the hero block)
2. The filters, images, slide cards, etc. are all shifted after rendering, which is due to the hero block being generated in the lazy phase after all blocks have been already shown on screen

## Fix

To fix the issue we made the following changes:

1. Building the hero block in the eager phase of the template
4. Fixing the order of sections so cards appear before the "Latest Articles"
5. Add skeleton placeholders to reserve the card space until they actually load
6. Fix skeleton animation activation so it works in that context

## Results

| Mobile | Desktop |
|-|-|
| <img width="962" alt="Screenshot 2024-08-02 at 15 26 50" src="https://github.com/user-attachments/assets/1c784e1d-9494-43f6-bea8-63a9c2a6521d"> | <img width="961" alt="Screenshot 2024-08-02 at 15 27 00" src="https://github.com/user-attachments/assets/d996b7a5-9a48-4fff-a79e-3efa1b33f472"> |

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.live/
- After:
  - https://fix-breed-index-cls--petplace--hlxsites.hlx.live/article/breed/
  - https://fix-breed-index-cls--petplace--hlxsites.hlx.live/article/breed/?martech=off
