### PR TITLE
fix: soft redirects should point to real 404 page so Google properly marks it in GSC

### DIFF
--- a/templates/category-index/category-index.js
+++ b/templates/category-index/category-index.js
@@ -134,7 +134,8 @@ async function updateMetadata() {
   }
   const result = pageCategory;
   if (!result) {
-    throw new Error(404);
+    window.location.replace(`/invalid-category/${window.location.pathname.split('/').pop()}`);
+    return;
   }
   const { Name, Category, Path } = result;
   document.title = Name || Category;

--- a/templates/tag-index/tag-index.js
+++ b/templates/tag-index/tag-index.js
@@ -85,7 +85,8 @@ function createTemplateBlock(main, blockName, elems = []) {
 async function updateMetadata() {
   const tag = await getTagForUrl();
   if (!tag) {
-    throw new Error(404);
+    window.location.replace(`/invalid-tag/${window.location.pathname.split('/').pop()}`);
+    return;
   }
   const { Name } = tag;
   document.title = `${Name} | ${document.title}`;


### PR DESCRIPTION
Currently, categories and tags index pages will return a soft 404 when the specified category/tag does not exist.
This flags the page as a soft 404 in the Google Search Index. The recommendation is to change this so we return a proper 404 page (i.e. via JS redirection).


Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://fix-soft-redirects--petplace--hlxsites.hlx.live/article/category/some-invalid-category
  - https://fix-soft-redirects--petplace--hlxsites.hlx.live/article/category/some-invalid-category?martech=off
