### PR TITLE
Updated fstab.yaml to redirect checkout routes to a single document

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -10,3 +10,4 @@ folders:
   /en-gb/article/category/: /en-gb/article/category/default
   /en-gb/tags/: /en-gb/tags/default
   /account/: /account/default
+  /checkout/: /checkout/default


### PR DESCRIPTION
We want all /checkout/ routes to render into a single document, the same way we did for the /account/ route.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://checkout-redirect-rule--petplace--hlxsites.hlx.live/
  - https://checkout-redirect-rule--petplace--hlxsites.hlx.live/?martech=off
