### PR TITLE
feat: properly resolve legacy category instead of 404

### DIFF
--- a/templates/category-index/category-index.js
+++ b/templates/category-index/category-index.js
@@ -45,7 +45,12 @@ export async function getCategoryImage(path) {
 
 export async function getCategoryOrTagForUrl() {
   const { pathname } = window.location;
-  const [category] = pathname.split('/').splice(pathname.endsWith('/') ? -2 : -1, 1);
+  const hasLegacyPagination = pathname.split('/').includes('page');
+  const offset = (hasLegacyPagination && pathname.endsWith('/') && -4)
+    || (hasLegacyPagination && pathname.endsWith('/') && -3)
+    || (pathname.endsWith('/') && -2)
+    || -1;
+  const [category] = pathname.split('/').splice(offset, 1);
   const catResult = await getCategory(category);
   if (catResult) {
     return catResult;


### PR DESCRIPTION
Referral traffic still reaches the site using old paginated category URLs with the form `…/page/3/`, which breaks our category detection on the category index pages.

The PR fixes this so we serve the main category page instead. Actual page index is consciously ignored, as the canonical will properly be set to the 1st page, and thus googe search won't index the duplicated content.

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.live/article/category/pet-health/small-pet-health/fish-small-pet-health/page/3/
- After:
  - https://<branch>--petplace--hlxsites.hlx.live/article/category/pet-health/small-pet-health/fish-small-pet-health/page/3/
  - https://<branch>--petplace--hlxsites.hlx.live/article/category/pet-health/small-pet-health/fish-small-pet-health/page/3/?martech=off
