### PR TITLE
fix: prerender aware RUM & analytics tracking and ads improvessions

### DIFF
--- a/scripts/adsense.js
+++ b/scripts/adsense.js
@@ -156,7 +156,7 @@ const adsenseSetup = (adArgs, catVal) => {
 };
 
 const adsDefineSlot = async (adArgs, catVal) => {
-  window.googletag.cmd.push(async () => {
+  const fn = async () => {
     // separate function to return the anchor slot
     const anchorSlot = await adsenseSetup(adArgs, catVal);
 
@@ -164,7 +164,17 @@ const adsDefineSlot = async (adArgs, catVal) => {
     const newArgs = adArgs.filter((arg) => !arg.includes('anchor'));
     if (anchorSlot) newArgs.push(anchorSlot);
     gtagDisplay(newArgs);
-  });
+  };
+
+  // Speculative prerender-aware adsense instrumentation
+  // based on https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API#unsafe_prerendering
+  if (document.prerendering) {
+    document.addEventListener('prerenderingchange', () => {
+      window.googletag.cmd.push(fn);
+    }, { once: true });
+  } else {
+    window.googletag.cmd.push(fn);
+  }
 };
 
 // google tag for adsense

--- a/scripts/adsense.js
+++ b/scripts/adsense.js
@@ -1,3 +1,4 @@
+import { onPageActivation } from './scripts.js';
 import { isMiddleAd, mappingHelper, sizingArr } from './utils/helpers.js';
 
 window.googletag ||= { cmd: [] };
@@ -166,15 +167,7 @@ const adsDefineSlot = async (adArgs, catVal) => {
     gtagDisplay(newArgs);
   };
 
-  // Speculative prerender-aware adsense instrumentation
-  // based on https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API#unsafe_prerendering
-  if (document.prerendering) {
-    document.addEventListener('prerenderingchange', () => {
-      window.googletag.cmd.push(fn);
-    }, { once: true });
-  } else {
-    window.googletag.cmd.push(fn);
-  }
+  onPageActivation(() => window.googletag.cmd.push(fn));
 };
 
 // google tag for adsense

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -897,16 +897,16 @@ function init() {
   document.body.style.display = 'none';
   setup();
 
+  const cb = () => {
+    sampleRUM('top');
+    window.addEventListener('load', () => sampleRUM('load'));
+  };
   // Speculative prerender-aware sampleRUM instrumentation
   // based on https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API#unsafe_prerendering
   if (document.prerendering) {
-    document.addEventListener('prerenderingchange', () => {
-      sampleRUM('top');
-      window.addEventListener('load', () => sampleRUM('load'));
-    }, { once: true });
+    document.addEventListener('prerenderingchange', cb, { once: true });
   } else {
-    sampleRUM('top');
-    window.addEventListener('load', () => sampleRUM('load'));
+    cb();
   }
 
   window.addEventListener('unhandledrejection', (event) => {

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -896,9 +896,18 @@ export function setup() {
 function init() {
   document.body.style.display = 'none';
   setup();
-  sampleRUM('top');
 
-  window.addEventListener('load', () => sampleRUM('load'));
+  // Speculative prerender-aware sampleRUM instrumentation
+  // based on https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API#unsafe_prerendering
+  if (document.prerendering) {
+    document.addEventListener('prerenderingchange', () => {
+      sampleRUM('top');
+      window.addEventListener('load', () => sampleRUM('load'));
+    }, { once: true });
+  } else {
+    sampleRUM('top');
+    window.addEventListener('load', () => sampleRUM('load'));
+  }
 
   window.addEventListener('unhandledrejection', (event) => {
     sampleRUM('error', { source: event.reason.sourceURL, target: event.reason.line });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -166,6 +166,21 @@ async function loadFonts() {
   }
 }
 
+/**
+ * Triggers the callback when the page is actually activated,
+ * This is to properly handle speculative page prerendering and marketing events.
+ * @param {Function} cb The callback to run
+ */
+export async function onPageActivation(cb) {
+  // Speculative prerender-aware execution.
+  // See: https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API#unsafe_prerendering
+  if (document.prerendering) {
+    document.addEventListener('prerenderingchange', cb, { once: true });
+  } else {
+    cb();
+  }
+}
+
 let queue = 0;
 /**
  * Perform some metering on a repeated function call to reduce the chances to block the CPU/GPU

--- a/scripts/third-party.js
+++ b/scripts/third-party.js
@@ -1,6 +1,6 @@
 import { loadScript } from './lib-franklin.js';
 // eslint-disable-next-line import/no-cycle
-import { isMobile } from './scripts.js';
+import { isMobile, onPageActivation } from './scripts.js';
 
 async function loadAccessibeWidget() {
   await loadScript('https://acsbapp.com/apps/app/dist/js/app.js', { async: true });
@@ -33,14 +33,18 @@ async function loadAccessibeWidget() {
 }
 
 function loadMSClarity() {
-  return loadScript('https://www.clarity.ms/tag/hz6a0je2i3?ref=gtm2', { async: true });
+  onPageActivation(() => {
+    loadScript('https://www.clarity.ms/tag/hz6a0je2i3?ref=gtm2', { async: true });
+  });
 }
 
 async function loadPushlySdk() {
   function pushly(...args) { window.PushlySDK.push(args); }
-  pushly('load', {
-    domainKey: 'cfOCEQj2H76JJXktWCy3uK0OZCb1DMbfNUnq',
-    sw: '/scripts/pushly-sdk-worker.js',
+  onPageActivation(() => {
+    pushly('load', {
+      domainKey: 'cfOCEQj2H76JJXktWCy3uK0OZCb1DMbfNUnq',
+      sw: '/scripts/pushly-sdk-worker.js',
+    });
   });
   return loadScript('https://cdn.p-n.io/pushly-sdk.min.js?domain_key=cfOCEQj2H76JJXktWCy3uK0OZCb1DMbfNUnq', { async: true });
 }


### PR DESCRIPTION
After enabling speculative prerendering to speed up the page rendering during navigation, we saw an increase in various 3rd-party metrics being tracked (page views, etc.). This PRs properly wraps those instrumentation behind prerender compatible events so they only trigger if the page is actually activated (i.e. navigated to) by the end user

Test URLs:
- Before: https://main--petplace--hlxsites.hlx.page/
- After:
  - https://fix-prerender--petplace--hlxsites.hlx.live/
  - https://fix-prerender--petplace--hlxsites.hlx.live/?martech=off
