### PR TITLE
fix: 84734 unable to access pet profile

### DIFF
--- a/react-client/src/routes/my-pets/petId/useRenewMembershipViewModel.ts
+++ b/react-client/src/routes/my-pets/petId/useRenewMembershipViewModel.ts
@@ -127,7 +127,7 @@ export const useRenewMembershipViewModel = ({
     // If annual member with no products, return only direct-connect and recovery-specialists
 
     if (!products?.length || hasAnnualProduct)
-      return petWatchAvailableBenefits.filter(
+      return petWatchAvailableBenefits?.filter(
         (benefit) =>
           benefit.id === "direct-connect" ||
           benefit.id === "recovery-specialists"


### PR DESCRIPTION
This PR solves the issue:
 - https://phits.visualstudio.com/PetPlace/_workitems/edit/84734

![image](https://github.com/user-attachments/assets/7c0e1d41-7c8d-4bc9-95c8-7b7f86de1284)
before


![image](https://github.com/user-attachments/assets/a5417541-f253-445a-9e67-7eff558126e3)

after


Test URLs:
- Before: https://dev--petplace--hlxsites.hlx.page/
- After:
  - https://fix-84734--petplace--hlxsites.hlx.live/
  - https://fix-84734--petplace--hlxsites.hlx.live/?martech=off
